### PR TITLE
Update LoginMechanismProcessor.cs

### DIFF
--- a/Rnwood.SmtpServer/Extensions/Auth/LoginMechanismProcessor.cs
+++ b/Rnwood.SmtpServer/Extensions/Auth/LoginMechanismProcessor.cs
@@ -18,7 +18,7 @@ namespace Rnwood.SmtpServer.Extensions.Auth
 
         public async override Task<AuthMechanismProcessorStatus> ProcessResponseAsync(string data)
         {
-            if (data != null)
+            if (data != null && this.State == States.Initial)
             {
                 State = States.WaitingForUsername;
             }


### PR DESCRIPTION
The first call to ProcessResponseAsync contains the base64 encoded username from the Arguments and it exits having set State to WaitingForPassword.

The second call to ProcessResponseAsync has the base64 encoded password and the state is correctly set to WaitingForPassword, however the first thing it does is set the state to WaitingForUsername which leads to badness.

My change checks for the initial state so that the defaulting of state to WaitingForUsername only occurs on the first call.