### PR TITLE
Support CLI arguments to configure the Kestrel Http Server

### DIFF
--- a/Rnwood.Smtp4dev/Program.cs
+++ b/Rnwood.Smtp4dev/Program.cs
@@ -17,9 +17,16 @@ namespace Rnwood.Smtp4dev
             BuildWebHost(args).Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
+        public static IWebHost BuildWebHost(string[] args)
+        {
+            var config = new ConfigurationBuilder()
+                .AddCommandLine(args)
+                .Build();
+
+            return WebHost.CreateDefaultBuilder(args)
+                .UseConfiguration(config)
                 .UseStartup<Startup>()
                 .Build();
+        }
     }
 }


### PR DESCRIPTION
Support command line arguments to configure the Kestrel HTTP Server. For intance you could make the smtp4dev api client listen on all IPv4 addresses and a non-standard port instead of the environment variable workaround as mentioned in #22

Example:
`dotnet Rnwood.Smtp4dev.dll --server.urls "http://0.0.0.0:5001/"`

It would've been nicer if these settings could be defined in the appsettings.json, but that currently doesn't seem to be support by .NET core. However it seems this might get solved soon. 

Related issues: 
https://github.com/aspnet/KestrelHttpServer/issues/1290
https://github.com/aspnet/Hosting/issues/1299

