### PR TITLE
Add blank target to open links in new window

### DIFF
--- a/Rnwood.Smtp4dev/components/messageviewhtml.html
+++ b/Rnwood.Smtp4dev/components/messageviewhtml.html
@@ -11,7 +11,7 @@
     </template>
 
     <template v-if="html">
-        <iframe class="fill" :srcdoc="html"></iframe>
+        <iframe @load="addAnchorTarget" class="fill" :srcdoc="html"></iframe>
     </template>
 
 </div>

--- a/Rnwood.Smtp4dev/components/messageviewhtml.ts
+++ b/Rnwood.Smtp4dev/components/messageviewhtml.ts
@@ -51,4 +51,16 @@ export default class MessageViewHtml extends Vue {
     async destroyed() {
         
     }
+
+    async addAnchorTarget() {
+        const iframe = document.getElementsByTagName("iframe").length > 0 ? document.getElementsByTagName("iframe")[0] : null;
+        if (iframe != null && iframe.contentDocument != null) {
+            const anchors = iframe.contentDocument.querySelectorAll("a");
+            if (anchors != null) {
+                for (let i = 0; i < anchors.length; i++) {
+                    anchors[i].setAttribute("target", "_blank");
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
When clicking on an email with a link, the linked page opens in the iframe which may be blocked by X-Frame-Options. This change adds: target="_blank" to any link in the iframe, so links open in a new tab/window and get rendered correctly. 