### PR TITLE
Updated Dockerfiles to only reference one version of the .NET framewo…

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.2-sdk AS build
+FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
 WORKDIR /app
 
 ARG version
@@ -43,7 +43,7 @@ FROM build AS publish
 WORKDIR /app/Rnwood.Smtp4dev
 RUN dotnet publish -c Release -o out -p:Version=$VERSION
 
-FROM microsoft/dotnet:2.1.5-aspnetcore-runtime AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
 WORKDIR /app
 EXPOSE 80
 EXPOSE 25

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -39,7 +39,7 @@ WORKDIR /app/Rnwood.Smtp4dev
 RUN dotnet build -p:Version=$env:VERSION
 RUN dotnet publish -c Release -o out -p:Version=$env:VERSION
 
-FROM microsoft/dotnet:2.1.5-aspnetcore-runtime AS runtime
+FROM mcr.microsoft.com/dotnet/core/aspnet:2.2 AS runtime
 WORKDIR /app
 EXPOSE 80
 EXPOSE 25


### PR DESCRIPTION
Addresses [115](https://github.com/rnwood/smtp4dev/issues/115).

Updated Dockerfiles to only reference one version of the .NET framework and to change base image references to be pulled from the MCR.