### PR TITLE
Use double quotes for array syntax

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -45,7 +45,7 @@ RUN dotnet publish --no-restore -c Release -o out -p:Version=$VERSION
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.2 AS runtime
 COPY --from=publish /app/Rnwood.Smtp4dev/out /app
-VOLUME ['/smtp4dev']
+VOLUME ["/smtp4dev"]
 WORKDIR /
 ENV XDG_CONFIG_HOME /
 EXPOSE 80


### PR DESCRIPTION
The Dockerfile docs as https://docs.docker.com/engine/reference/builder/#volume say:

> JSON formatting: The list is parsed as a JSON array. You must enclose words with double quotes (") rather than single quotes (').