### PR TITLE
feat: disable remote connections by default

### DIFF
--- a/Rnwood.Smtp4dev/appsettings.json
+++ b/Rnwood.Smtp4dev/appsettings.json
@@ -38,7 +38,7 @@
 
     //Specifies if remote connections will be allowed to the SMTP and IMAP servers
     //Default value: true
-    "AllowRemoteConnections": true,
+    "AllowRemoteConnections": false,
 
     //Specifies the path where the database will be stored relative to APPDATA env var on Windows or XDG_CONFIG_HOME on non-Windows. Specify "" to use an in memory database.
     //Default value: "database.db"


### PR DESCRIPTION
Running a SMTP server allowing remote connections is prohibited in my employer's net while running one that does not accept remote connections is OK. 

I assume there are others with the same difficulty, so the default should be to not allow remote connections