### PR TITLE
feat (UI/SecureConnection): Add Secure connection transport status of…

### DIFF
--- a/Rnwood.Smtp4dev/ApiModel/Message.cs
+++ b/Rnwood.Smtp4dev/ApiModel/Message.cs
@@ -3,18 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using Rnwood.Smtp4dev.DbModel;
-using System.Net.Http.Headers;
-using Rnwood.Smtp4dev;
+using Newtonsoft.Json;
 
 namespace Rnwood.Smtp4dev.ApiModel
 {
     public class Message : ICacheByKey
     {
-
 
         public Message(DbModel.Message dbMessage)
         {
@@ -26,6 +21,7 @@ namespace Rnwood.Smtp4dev.ApiModel
             Bcc = "";
             ReceivedDate = dbMessage.ReceivedDate;
             Subject = dbMessage.Subject;
+            SecureConnection = dbMessage.SecureConnection;
 
             Parts = new List<ApiModel.MessageEntitySummary>();
             RelayError = dbMessage.RelayError;
@@ -204,6 +200,8 @@ namespace Rnwood.Smtp4dev.ApiModel
         public string Cc { get; set; }
         public string Bcc { get; set; }
         public DateTime ReceivedDate { get; set; }
+        
+        public bool SecureConnection { get; set; }
 
         public string Subject { get; set; }
 

--- a/Rnwood.Smtp4dev/ClientApp/src/ApiClient/Message.ts
+++ b/Rnwood.Smtp4dev/ClientApp/src/ApiClient/Message.ts
@@ -1,35 +1,46 @@
-﻿
-//MessageEntitySummary[] from Message
-import MessageEntitySummary from './MessageEntitySummary';
-//Header[] from Message
-import Header from './Header';
+﻿//MessageEntitySummary[] from Message
+import MessageEntitySummary from "./MessageEntitySummary";
+//Header[] from Message 
+import Header from "./Header";
 export default class Message {
- 
-    constructor(id: string, from: string, to: string, cc: string, bcc: string, receivedDate: Date, subject: string, parts: MessageEntitySummary[], headers: Header[], mimeParseError: string, relayError: string, ) {
-         
-        this.id = id; 
-        this.from = from; 
-        this.to = to; 
-        this.cc = cc; 
-        this.bcc = bcc; 
-        this.receivedDate = receivedDate; 
-        this.subject = subject; 
-        this.parts = parts; 
-        this.headers = headers; 
-        this.mimeParseError = mimeParseError; 
-        this.relayError = relayError;
-    }
+  constructor(
+    id: string,
+    from: string,
+    to: string,
+    cc: string,
+    bcc: string,
+    receivedDate: Date,
+    subject: string,
+    parts: MessageEntitySummary[],
+    headers: Header[],
+    mimeParseError: string,
+    relayError: string,
+    secureConnection: boolean,
+  ) {
+    this.id = id;
+    this.from = from;
+    this.to = to;
+    this.cc = cc;
+    this.bcc = bcc;
+    this.receivedDate = receivedDate;
+    this.subject = subject;
+    this.parts = parts;
+    this.headers = headers;
+    this.mimeParseError = mimeParseError;
+    this.relayError = relayError;
+    this.secureConnection = secureConnection;
+  }
 
-     
-    id: string; 
-    from: string; 
-    to: string; 
-    cc: string; 
-    bcc: string; 
-    receivedDate: Date; 
-    subject: string; 
-    parts: MessageEntitySummary[]; 
-    headers: Header[]; 
-    mimeParseError: string; 
-    relayError: string;
+  id: string;
+  from: string;
+  to: string;
+  cc: string;
+  bcc: string;
+  receivedDate: Date;
+  subject: string;
+  parts: MessageEntitySummary[];
+  headers: Header[];
+  mimeParseError: string;
+  relayError: string;
+  secureConnection: boolean;
 }

--- a/Rnwood.Smtp4dev/ClientApp/src/components/messageview.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/messageview.vue
@@ -42,6 +42,10 @@
                         <td>Subject:</td>
                         <td><span v-if="message">{{message.subject}}</span></td>
                     </tr>
+                    <tr>
+                        <td>Secure:</td>
+                        <td><span v-if="message">{{message.secureConnection}}</span></td>
+                    </tr>
                 </table>
 
 

--- a/Rnwood.Smtp4dev/DbModel/Message.cs
+++ b/Rnwood.Smtp4dev/DbModel/Message.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Rnwood.Smtp4dev.DbModel
 {
@@ -11,7 +8,6 @@ namespace Rnwood.Smtp4dev.DbModel
 
         public Message()
         {
-
         }
 
         [Key]
@@ -34,5 +30,7 @@ namespace Rnwood.Smtp4dev.DbModel
 
         public bool IsUnread { get; set; }
         public string RelayError { get; internal set; }
+        
+        public bool SecureConnection { get; set; }
     }
 }

--- a/Rnwood.Smtp4dev/Migrations/20210211134331_AddMessageSecurity.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210211134331_AddMessageSecurity.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations
 {
     [DbContext(typeof(Smtp4devDbContext))]
-    partial class Smtp4devDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210211134331_AddMessageSecurity")]
+    partial class AddMessageSecurity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Rnwood.Smtp4dev/Migrations/20210211134331_AddMessageSecurity.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210211134331_AddMessageSecurity.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Rnwood.Smtp4dev.Migrations
+{
+    public partial class AddMessageSecurity : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "SecureConnection",
+                table: "Messages",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SecureConnection",
+                table: "Messages");
+        }
+    }
+}

--- a/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
@@ -281,9 +281,8 @@ namespace Rnwood.Smtp4dev.Server
         {
             using (Stream stream = e.Message.GetData().Result)
             {
-                string to = string.Join(", ", e.Message.Recipients);
-                Console.WriteLine($"Message received. Client address {e.Message.Session.ClientAddress}. From {e.Message.From}. To {to}.");
-                Message message = new MessageConverter().ConvertAsync(stream, e.Message.From, to).Result;
+                Message message = new MessageConverter().ConvertAsync(stream, e.Message).Result;
+                Console.WriteLine($"Message received. Client address {e.Message.Session.ClientAddress}. From {e.Message.From}. To {message.To}.");
                 message.IsUnread = true;
 
 


### PR DESCRIPTION
This PR adds the state of the transport security for the message.  It relates to #596 .  But I could find any trace of the TLS connection details in the header array.    Perhaps this is useful to assist.

Stores the SecureConnection value against each message and exposes it in the UI. 

![image](https://user-images.githubusercontent.com/127927/107651137-e53b6280-6cca-11eb-8060-da781251fc56.png)
