### PR TITLE
fix (memory): Create a scoped DbContext to reduce memory usageof SmtpServer - relates to #592

### DIFF
--- a/Rnwood.Smtp4dev/Startup.cs
+++ b/Rnwood.Smtp4dev/Startup.cs
@@ -59,7 +59,6 @@ namespace Rnwood.Smtp4dev
             services.AddSingleton<Smtp4devServer>();
             services.AddSingleton<ImapServer>();
             services.AddSingleton<IMessagesRepository>(sp => sp.GetService<Smtp4devServer>());
-            services.AddSingleton<Func<Smtp4devDbContext>>(sp => (() => sp.GetService<Smtp4devDbContext>()));
 
             services.AddSingleton<Func<RelayOptions, SmtpClient>>((relayOptions) =>
             {


### PR DESCRIPTION
# Reduce memory footprint by scoping DbContext

## Test Run

```
Testrunner: K6
Hit /api/Messages reading set of messages
Iteration count: 5000
```

## Results

Before change, memory usage peaks 1.2GB+

![dotMemory UI 64_dIdPfTAmZt](https://user-images.githubusercontent.com/127927/117514611-97877b00-afd7-11eb-9407-e361e9352244.png)

After patch: memory usage peaks at ~650mb

![dotMemory UI 64_SseqLwoTgR](https://user-images.githubusercontent.com/127927/117514677-c867b000-afd7-11eb-919d-50898bc4e2cd.png)


## Minor other change
* Spelling on dbContext