### PR TITLE
refactor (repository): Move methods into repository class.  Upgrade EFCore to 5.0.5

### DIFF
--- a/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
+++ b/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="89.0.4389.2300" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Rnwood.Smtp4dev.Tests/TestMessagesRepository.cs
+++ b/Rnwood.Smtp4dev.Tests/TestMessagesRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Tests
@@ -28,7 +29,7 @@ namespace Rnwood.Smtp4dev.Tests
 			return Task.CompletedTask;
 		}
 
-		public IQueryable<Message> GetMessages()
+		public IQueryable<Message> GetMessages(bool unTracked = true)
 		{
 			return Messages.AsQueryable();
 		}

--- a/Rnwood.Smtp4dev/ApiModel/Message.cs
+++ b/Rnwood.Smtp4dev/ApiModel/Message.cs
@@ -183,7 +183,7 @@ namespace Rnwood.Smtp4dev.ApiModel
 
         private static MimeEntity GetPart(Message message, string id)
         {
-            MessageEntitySummary part = message.Parts.Flatten(p => p.ChildParts).FirstOrDefault(p => p.Id == id);
+            MessageEntitySummary part = message.Parts.Flatten(p => p.ChildParts).SingleOrDefault(p => p.Id == id);
 
             if (part == null)
             {

--- a/Rnwood.Smtp4dev/Controllers/MessagesController.cs
+++ b/Rnwood.Smtp4dev/Controllers/MessagesController.cs
@@ -45,7 +45,7 @@ namespace Rnwood.Smtp4dev.Controllers
 
 		private DbModel.Message GetDbMessage(Guid id)
 		{
-			return messagesRepository.GetMessages().FirstOrDefault(m => m.Id == id) ??
+			return messagesRepository.GetMessages().SingleOrDefault(m => m.Id == id) ??
 				throw new FileNotFoundException($"Message with id {id} was not found.");
 		}
 
@@ -151,7 +151,7 @@ namespace Rnwood.Smtp4dev.Controllers
 				{
 					string cid = imageElement.Attributes["src"].Value.Replace("cid:", "", StringComparison.OrdinalIgnoreCase);
 
-					var part = message.Parts.Flatten(p => p.ChildParts).FirstOrDefault(p => p.ContentId == cid);
+					var part = message.Parts.Flatten(p => p.ChildParts).SingleOrDefault(p => p.ContentId == cid);
 
 					imageElement.Attributes["src"].Value = $"api/Messages/{id.ToString()}/part/{part?.Id ?? "notfound"}/content";
 				}

--- a/Rnwood.Smtp4dev/Controllers/MessagesController.cs
+++ b/Rnwood.Smtp4dev/Controllers/MessagesController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.Entity;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -10,13 +11,12 @@ using HtmlAgilityPack;
 using Microsoft.AspNetCore.Mvc;
 
 using Rnwood.Smtp4dev.ApiModel;
-using Rnwood.Smtp4dev.DbModel;
-using Rnwood.Smtp4dev.Hubs;
 using System.Linq.Dynamic.Core;
 
 using Message = Rnwood.Smtp4dev.DbModel.Message;
 using Rnwood.Smtp4dev.Server;
 using MimeKit;
+using Rnwood.Smtp4dev.Data;
 
 namespace Rnwood.Smtp4dev.Controllers
 {
@@ -31,8 +31,8 @@ namespace Rnwood.Smtp4dev.Controllers
 			this.server = server;
 		}
 
-		private IMessagesRepository messagesRepository;
-		private Smtp4devServer server;
+		private readonly IMessagesRepository messagesRepository;
+		private readonly Smtp4devServer server;
 
 		[HttpGet]
 
@@ -40,20 +40,18 @@ namespace Rnwood.Smtp4dev.Controllers
 		{
 			return messagesRepository.GetMessages()
 			.OrderBy(sortColumn + (sortIsDescending ? " DESC" : ""))
-			.Select(m => new ApiModel.MessageSummary(m));
+			.Select(m => new MessageSummary(m));
 		}
 
-		private DbModel.Message GetDbMessage(Guid id)
-		{
-			return messagesRepository.GetMessages().SingleOrDefault(m => m.Id == id) ??
-				throw new FileNotFoundException($"Message with id {id} was not found.");
+		private Message GetDbMessage(Guid id)
+        {
+			return messagesRepository.GetMessages().SingleOrDefault(m => m.Id == id) ?? throw new FileNotFoundException($"Message with id {id} was not found.");
 		}
 
 		[HttpGet("{id}")]
 		public ApiModel.Message GetMessage(Guid id)
 		{
-			var result = new ApiModel.Message(GetDbMessage(id));
-			return result;
+			return new ApiModel.Message(GetDbMessage(id));
 		}
 
 		[HttpPost("{id}")]

--- a/Rnwood.Smtp4dev/Controllers/SessionsController.cs
+++ b/Rnwood.Smtp4dev/Controllers/SessionsController.cs
@@ -10,6 +10,7 @@ using Newtonsoft.Json;
 using System.IO;
 using MimeKit;
 using HtmlAgilityPack;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.Server;
 
 namespace Rnwood.Smtp4dev.Controllers

--- a/Rnwood.Smtp4dev/Controllers/SessionsController.cs
+++ b/Rnwood.Smtp4dev/Controllers/SessionsController.cs
@@ -39,14 +39,14 @@ namespace Rnwood.Smtp4dev.Controllers
         [HttpGet("{id}")]
         public ApiModel.Session GetSession(Guid id)
         {
-            Session result = dbContext.Sessions.FirstOrDefault(m => m.Id == id);
+            Session result = dbContext.Sessions.SingleOrDefault(m => m.Id == id);
             return new ApiModel.Session(result);
         }
 
         [HttpGet("{id}/log")]
         public string GetSessionLog(Guid id)
         {
-            Session result = dbContext.Sessions.FirstOrDefault(m => m.Id == id);
+            Session result = dbContext.Sessions.SingleOrDefault(m => m.Id == id);
             return result.Log;
         }
 

--- a/Rnwood.Smtp4dev/Data/IMessagesRepository.cs
+++ b/Rnwood.Smtp4dev/Data/IMessagesRepository.cs
@@ -1,15 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Rnwood.Smtp4dev
+namespace Rnwood.Smtp4dev.Data
 {
 	public interface IMessagesRepository
 	{
 		Task MarkMessageRead(Guid id);
 
-		IQueryable<DbModel.Message> GetMessages();
+		IQueryable<DbModel.Message> GetMessages(bool unTracked = true);
 
 		Task DeleteMessage(Guid id);
 

--- a/Rnwood.Smtp4dev/Data/MessagesRepository.cs
+++ b/Rnwood.Smtp4dev/Data/MessagesRepository.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Rnwood.Smtp4dev.DbModel;
+using Rnwood.Smtp4dev.Hubs;
+using Rnwood.Smtp4dev.Server;
+
+namespace Rnwood.Smtp4dev.Data
+{
+    public class MessagesRepository : IMessagesRepository
+    {
+        private readonly ITaskQueue taskQueue;
+        private readonly NotificationsHub notificationsHub;
+        private readonly Smtp4devDbContext dbContext;
+
+        public MessagesRepository(ITaskQueue taskQueue, NotificationsHub notificationsHub, Smtp4devDbContext dbContext)
+        {
+            this.taskQueue = taskQueue;
+            this.notificationsHub = notificationsHub;
+            this.dbContext = dbContext;
+        }
+
+        public Task MarkMessageRead(Guid id)
+        {
+            return taskQueue.QueueTask(() =>
+            {
+                var message = dbContext.Messages.FindAsync(id).Result;
+                if (message?.IsUnread != true) return;
+                message.IsUnread = false;
+                dbContext.SaveChanges();
+                notificationsHub.OnMessagesChanged().Wait();
+            }, true);
+        }
+
+        public IQueryable<Message> GetMessages(bool unTracked = true)
+        {
+            return unTracked ? dbContext.Messages.AsNoTracking() : dbContext.Messages;
+        }
+
+        public Task DeleteMessage(Guid id)
+        {
+            return taskQueue.QueueTask(() =>
+            {
+                dbContext.Messages.RemoveRange(dbContext.Messages.Where(m => m.Id == id));
+                dbContext.SaveChanges();
+                notificationsHub.OnMessagesChanged().Wait();
+            }, true);
+        }
+
+        public Task DeleteAllMessages()
+        {
+            return taskQueue.QueueTask(() =>
+            {
+                dbContext.Messages.RemoveRange(dbContext.Messages);
+                dbContext.SaveChanges();
+                notificationsHub.OnMessagesChanged().Wait();
+            }, true);
+        }
+    }
+}

--- a/Rnwood.Smtp4dev/Data/Smtp4devDbContext.cs
+++ b/Rnwood.Smtp4dev/Data/Smtp4devDbContext.cs
@@ -1,11 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using Rnwood.Smtp4dev.DbModel;
 
-namespace Rnwood.Smtp4dev.DbModel
+namespace Rnwood.Smtp4dev.Data
 {
     public class Smtp4devDbContext : DbContext
     {

--- a/Rnwood.Smtp4dev/DbModel/ImapState.cs
+++ b/Rnwood.Smtp4dev/DbModel/ImapState.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace Rnwood.Smtp4dev.DbModel
 {

--- a/Rnwood.Smtp4dev/DbModel/Session.cs
+++ b/Rnwood.Smtp4dev/DbModel/Session.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Threading.Tasks;
 using Rnwood.SmtpServer;
 
 namespace Rnwood.Smtp4dev.DbModel

--- a/Rnwood.Smtp4dev/Migrations/20181020095712_InitialCreate.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20181020095712_InitialCreate.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/20181021072518_AddSessionToMessageReln.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20181021072518_AddSessionToMessageReln.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/20181021105259_AddSessionStartData.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20181021105259_AddSessionStartData.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/20181022132948_AddSessionErrorInfo.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20181022132948_AddSessionErrorInfo.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/20181022163054_AddAttachmentCount.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20181022163054_AddAttachmentCount.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/20190310130227_AddMessageUnreadFlag.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20190310130227_AddMessageUnreadFlag.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/20200904135503_AddRelayError.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20200904135503_AddRelayError.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/20200924120747_AddImapState.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20200924120747_AddImapState.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/20210211134331_AddMessageSecurity.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210211134331_AddMessageSecurity.Designer.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Migrations/Smtp4devDbContextModelSnapshot.cs
+++ b/Rnwood.Smtp4dev/Migrations/Smtp4devDbContextModelSnapshot.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Rnwood.Smtp4dev.Data;
 using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations

--- a/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
+++ b/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
@@ -27,6 +27,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="5.0.5" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>

--- a/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
+++ b/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
@@ -27,12 +27,12 @@
 		<PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.13">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.13" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.13" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.5" />
 		<PackageReference Include="MimeKit" Version="2.11.0" />
 		<PackageReference Include="Mono.Options" Version="6.6.0.161" />
 		<PackageReference Include="New.LumiSoft.Net" Version="1.0.0" />

--- a/Rnwood.Smtp4dev/Server/ImapServer.cs
+++ b/Rnwood.Smtp4dev/Server/ImapServer.cs
@@ -30,7 +30,7 @@ namespace Rnwood.Smtp4dev.Server
 
             using var scope = serviceScopeFactory.CreateScope();
             var dbContext = scope.ServiceProvider.GetService<Smtp4devDbContext>();
-            if (dbContext.ImapState.FirstOrDefault() == null)
+            if (!dbContext.ImapState.Any())
             {
                 dbContext.Add(new ImapState
                 {
@@ -162,7 +162,7 @@ namespace Rnwood.Smtp4dev.Server
             {
                 foreach (var msgInfo in e.MessagesInfo)
                 {
-                    var dbMessage = this.messagesRepository.GetMessages().FirstOrDefault(m => m.Id == new Guid(msgInfo.ID));
+                    var dbMessage = this.messagesRepository.GetMessages().SingleOrDefault(m => m.Id == new Guid(msgInfo.ID));
 
                     if (dbMessage != null)
                     {

--- a/Rnwood.Smtp4dev/Server/ImapServer.cs
+++ b/Rnwood.Smtp4dev/Server/ImapServer.cs
@@ -13,6 +13,7 @@ using System.Net;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
+using Rnwood.Smtp4dev.Data;
 
 namespace Rnwood.Smtp4dev.Server
 {

--- a/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
@@ -260,8 +260,7 @@ namespace Rnwood.Smtp4dev.Server
             {
                 using var scope = serviceScopeFactory.CreateScope();
                 Smtp4devDbContext dbContext = scope.ServiceProvider.GetService<Smtp4devDbContext>();
-
-                Session session = dbContext.Sessions.FirstOrDefault(s => s.Id == id);
+                Session session = dbContext.Sessions.SingleOrDefault(s => s.Id == id);
                 if (session != null)
                 {
                     dbContext.Sessions.Remove(session);

--- a/Rnwood.Smtp4dev/Server/TaskQueue.cs
+++ b/Rnwood.Smtp4dev/Server/TaskQueue.cs
@@ -1,14 +1,17 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Rnwood.Smtp4dev.Server
 {
-    internal class TaskQueue
+    public interface ITaskQueue
     {
+        Task QueueTask(Action action, bool priority);
+        void Start();
+    }
 
+    public class TaskQueue : ITaskQueue
+    {
         private BlockingCollection<Action> processingQueue = new BlockingCollection<Action>();
 
         private BlockingCollection<Action> priorityProcessingQueue = new BlockingCollection<Action>();
@@ -30,7 +33,6 @@ namespace Rnwood.Smtp4dev.Server
 
                     tcs.SetException(e);
                 }
-
             };
 
 
@@ -53,7 +55,7 @@ namespace Rnwood.Smtp4dev.Server
                 Action nextItem;
                 try
                 {
-                    BlockingCollection<Action>.TakeFromAny(new[] { priorityProcessingQueue, processingQueue }, out nextItem);
+                    BlockingCollection<Action>.TakeFromAny(new[] {priorityProcessingQueue, processingQueue}, out nextItem);
                 }
                 catch (InvalidOperationException)
                 {
@@ -71,7 +73,7 @@ namespace Rnwood.Smtp4dev.Server
             return Task.CompletedTask;
         }
 
-        internal void Start()
+        public void Start()
         {
             Task.Run(ProcessingTaskWork);
         }

--- a/Rnwood.Smtp4dev/Startup.cs
+++ b/Rnwood.Smtp4dev/Startup.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.AspNetCore.SpaServices;
 using MailKit.Net.Smtp;
 using Microsoft.AspNetCore.Rewrite;
+using Rnwood.Smtp4dev.Data;
 
 namespace Rnwood.Smtp4dev
 {
@@ -54,11 +55,12 @@ namespace Rnwood.Smtp4dev
                     Console.WriteLine("Using Sqlite database at " + Path.GetFullPath(serverOptions.Database));
                     opt.UseSqlite($"Data Source='{serverOptions.Database}'");
                 }
-            }, ServiceLifetime.Transient, ServiceLifetime.Singleton);
+            }, ServiceLifetime.Scoped, ServiceLifetime.Singleton);
 
             services.AddSingleton<Smtp4devServer>();
             services.AddSingleton<ImapServer>();
-            services.AddSingleton<IMessagesRepository>(sp => sp.GetService<Smtp4devServer>());
+            services.AddScoped<IMessagesRepository, MessagesRepository>();
+            services.AddSingleton<ITaskQueue, TaskQueue>();
 
             services.AddSingleton<Func<RelayOptions, SmtpClient>>((relayOptions) =>
             {

--- a/Rnwood.Smtp4dev/Startup.cs
+++ b/Rnwood.Smtp4dev/Startup.cs
@@ -59,7 +59,6 @@ namespace Rnwood.Smtp4dev
             services.AddSingleton<Smtp4devServer>();
             services.AddSingleton<ImapServer>();
             services.AddSingleton<IMessagesRepository>(sp => sp.GetService<Smtp4devServer>());
-            services.AddSingleton<Func<Smtp4devDbContext>>(sp => (() => sp.GetService<Smtp4devDbContext>()));
 
             services.AddSingleton<Func<RelayOptions, SmtpClient>>((relayOptions) =>
             {


### PR DESCRIPTION
This builds on #714, and maybe opinionated so feel free to decline PR.
- Update EFCore to 5.05
- Change intent of request for FirstOrDefault to SingleOrDefault
- Move methods from IMessagesRepository into own class, away from  Smtp4DevServer  (SRP) 