### PR TITLE
fix (Search): Fixes search errors when subjectline is null #806

### DIFF
--- a/Rnwood.Smtp4dev/ClientApp/src/components/messagelist.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/messagelist.vue
@@ -252,9 +252,9 @@
 
       private searchTermPredicate(m: MessageSummary) {
         return !this.searchTerm ||
-            m.subject.localeIndexOf(this.searchTerm, undefined, {
+            (m.subject ? (m.subject.localeIndexOf(this.searchTerm, undefined, {
               sensitivity: "base"
-            }) != -1 ||
+            }) != -1 ) : false) ||
             m.to.localeIndexOf(this.searchTerm, undefined, {
               sensitivity: "base"
             }) != -1 ||


### PR DESCRIPTION
Allow search to work when subjectline is null. (#806 )
