### PR TITLE
feat (Date-handling): Store dates in UTC. (#807)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "3.1.7",
+      "version": "5.0.8",
       "commands": [
         "dotnet-ef"
       ]

--- a/Rnwood.Smtp4dev.Tests/DBMigrations/Helpers/FakeLocalTimeZone.cs
+++ b/Rnwood.Smtp4dev.Tests/DBMigrations/Helpers/FakeLocalTimeZone.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using ReflectionMagic;
+
+namespace Rnwood.Smtp4dev.Tests.DBMigrations.Helpers
+{
+    public class FakeLocalTimeZone : IDisposable
+    {
+        private readonly TimeZoneInfo _actualLocalTimeZoneInfo;
+
+        private static void SetLocalTimeZone(TimeZoneInfo timeZoneInfo)
+        {
+            typeof(TimeZoneInfo).AsDynamicType().s_cachedData._localTimeZone = timeZoneInfo;
+        }
+
+        public FakeLocalTimeZone(TimeZoneInfo timeZoneInfo)
+        {
+            _actualLocalTimeZoneInfo = TimeZoneInfo.Local;
+            SetLocalTimeZone(timeZoneInfo);
+        }
+
+        public void Dispose()
+        {
+            SetLocalTimeZone(_actualLocalTimeZoneInfo);
+        }
+    }
+}

--- a/Rnwood.Smtp4dev.Tests/DBMigrations/Helpers/SqliteInMemory.cs
+++ b/Rnwood.Smtp4dev.Tests/DBMigrations/Helpers/SqliteInMemory.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Rnwood.Smtp4dev.Data;
+
+namespace Rnwood.Smtp4dev.Tests.DBMigrations.Helpers
+{
+    public class SqliteInMemory : IDisposable
+    {
+        private readonly DbConnection _connection;
+
+        public SqliteInMemory()
+        {
+            this.ContextOptions = new DbContextOptionsBuilder<Smtp4devDbContext>()
+                .UseSqlite(CreateInMemoryDatabase())
+                .Options;
+            _connection = RelationalOptionsExtension.Extract(ContextOptions).Connection;
+            using var context = new Smtp4devDbContext(ContextOptions);
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
+            context.SaveChanges();
+        }
+
+        protected internal DbContextOptions<Smtp4devDbContext> ContextOptions { get; }
+
+        private DbConnection CreateInMemoryDatabase()
+        {
+            var connection = new SqliteConnection("Filename=:memory:");
+            connection.Open();
+            return connection;
+        }
+
+        public void Dispose() => _connection.Dispose();
+    }
+}

--- a/Rnwood.Smtp4dev.Tests/DBMigrations/Helpers/TimeZoneOffset.cs
+++ b/Rnwood.Smtp4dev.Tests/DBMigrations/Helpers/TimeZoneOffset.cs
@@ -1,0 +1,8 @@
+﻿namespace Rnwood.Smtp4dev.Tests.DBMigrations.Helpers
+{
+    public class TimeZoneOffset
+    {
+        public string Id { get; set; }
+        public int Offset { get; set; }
+    }
+}

--- a/Rnwood.Smtp4dev.Tests/DBMigrations/Helpers/TimeZoneOffset.cs
+++ b/Rnwood.Smtp4dev.Tests/DBMigrations/Helpers/TimeZoneOffset.cs
@@ -3,6 +3,7 @@
     public class TimeZoneOffset
     {
         public string Id { get; set; }
+        public string SerializedTimeZone { get; set; }
         public int Offset { get; set; }
     }
 }

--- a/Rnwood.Smtp4dev.Tests/DBMigrations/TimezoneConvertMigrationTests.cs
+++ b/Rnwood.Smtp4dev.Tests/DBMigrations/TimezoneConvertMigrationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.InteropServices;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Rnwood.Smtp4dev.Data;
@@ -25,7 +26,7 @@ namespace Rnwood.Smtp4dev.Tests.DBMigrations
             var timeZone = GetTestTimezone();
             var testDate = new DateTime(2021, 1, 4, 10, 0, 0, DateTimeKind.Utc);
 
-            using (new FakeLocalTimeZone(TimeZoneInfo.FindSystemTimeZoneById(timeZone.Id)))
+            using (new FakeLocalTimeZone(GetTimeZoneInfo(timeZone)))
             {
                 using (var context = new Smtp4devDbContext(_sqlLiteForTesting.ContextOptions))
                 {
@@ -84,7 +85,19 @@ SET ReceivedDate = DATETIME('{testDate:yyyy-MM-dd HH:mm:ss}');
 
         private TimeZoneOffset GetTestTimezone()
         {
-            return new TimeZoneOffset {Id = "Central America Standard Time", Offset = -6};
+            return new TimeZoneOffset
+            {
+                Id = "Central America Standard Time", Offset = -6, SerializedTimeZone =
+                    "Central America Standard Time;-360;(UTC-06:00) Central America;Central America Standard Time;Central America Summer Time;;"
+            };
+        }
+
+        private TimeZoneInfo GetTimeZoneInfo(TimeZoneOffset timeZoneOffset)
+        {
+            // See issue with crossPlatform TimeZoneById calls https://stackoverflow.com/questions/41566395/timezoneinfo-in-net-core-when-hosting-on-unix-nginx
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return TimeZoneInfo.FindSystemTimeZoneById(timeZoneOffset.Id);
+            return TimeZoneInfo.FromSerializedString(timeZoneOffset.SerializedTimeZone);
         }
     }
 }

--- a/Rnwood.Smtp4dev.Tests/DBMigrations/TimezoneConvertMigrationTests.cs
+++ b/Rnwood.Smtp4dev.Tests/DBMigrations/TimezoneConvertMigrationTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Rnwood.Smtp4dev.Data;
+using Rnwood.Smtp4dev.DbModel;
+using Rnwood.Smtp4dev.Migrations;
+using Rnwood.Smtp4dev.Tests.DBMigrations.Helpers;
+using Xunit;
+
+namespace Rnwood.Smtp4dev.Tests.DBMigrations
+{
+    public class TimezoneConvertMigrationTests
+    {
+        private readonly SqliteInMemory _sqlLiteForTesting;
+
+        public TimezoneConvertMigrationTests()
+        {
+            _sqlLiteForTesting = new SqliteInMemory();
+        }
+
+        [Fact]
+        public void DatesAreStoredInUtcAndKindIsSetOnRetrieval()
+        {
+            var timeZone = GetTestTimezone();
+            var testDate = new DateTime(2021, 1, 4, 10, 0, 0, DateTimeKind.Utc);
+
+            using (new FakeLocalTimeZone(TimeZoneInfo.FindSystemTimeZoneById(timeZone.Id)))
+            {
+                using (var context = new Smtp4devDbContext(_sqlLiteForTesting.ContextOptions))
+                {
+                    context.Messages.Add(new Message {From = "test"});
+                    context.SaveChanges();
+
+                    //manually set time so we don't go through any EF converts.
+                    var sql = @$"
+UPDATE Messages
+SET ReceivedDate = DATETIME('{testDate:yyyy-MM-dd HH:mm:ss}');
+";
+                    context.Database.ExecuteSqlRaw(sql);
+                    context.ChangeTracker.Clear();
+
+                    // verify entity return value
+                    var message = context.Messages.Single(x => x.From == "test");
+                    message.ReceivedDate.Kind.Should().Be(DateTimeKind.Utc);
+                    message.ReceivedDate.ToLocalTime().Should().Be(new DateTime(testDate.Year, testDate.Month, testDate.Day,
+                        testDate.Hour + timeZone.Offset, 0, 0, DateTimeKind.Local));
+                }
+            }
+        }
+
+        [Fact]
+        public void MigrationScriptMaintainsCorrectLocalTimeAfterCoversionTest()
+        {
+            var timeZone = GetTestTimezone();
+            var testDate = new DateTime(2021, 1, 4, 10, 0, 0, DateTimeKind.Utc);
+
+            using (new FakeLocalTimeZone(TimeZoneInfo.FindSystemTimeZoneById(timeZone.Id)))
+            {
+                using var context = new Smtp4devDbContext(_sqlLiteForTesting.ContextOptions);
+                context.Messages.Add(new Message {From = "test"});
+                context.Sessions.Add(new Session {Id = Guid.NewGuid(), Log = "Log"});
+                context.SaveChanges();
+
+                //manually set time so we don't go through any EF converts.  This will be the date pre migration (local time)
+                var sql = @$"
+UPDATE Messages
+SET ReceivedDate = DATETIME('{testDate:yyyy-MM-dd HH:mm:ss}');
+";
+                context.Database.ExecuteSqlRaw(sql);
+                context.ChangeTracker.Clear();
+
+                // Run Migration Script SQL to convert to UTC.
+                context.Database.ExecuteSqlRaw(UTCTimeMigration.CreateUpdateToUtcRawSql());
+
+                // verify entity return value is correct when retrieved for actual timezone.
+                var message = context.Messages.Single(x => x.From == "test");
+                message.Should().NotBeNull();
+                message.ReceivedDate.Kind.Should().Be(DateTimeKind.Utc);
+                message.ReceivedDate.ToLocalTime().Should().Be(new DateTime(testDate.Year, testDate.Month, testDate.Day,
+                    testDate.Hour, 0, 0, DateTimeKind.Local));
+            }
+        }
+
+        private TimeZoneOffset GetTestTimezone()
+        {
+            return new TimeZoneOffset {Id = "Central America Standard Time", Offset = -6};
+        }
+    }
+}

--- a/Rnwood.Smtp4dev.Tests/DBMigrations/TimezoneConvertMigrationTests.cs
+++ b/Rnwood.Smtp4dev.Tests/DBMigrations/TimezoneConvertMigrationTests.cs
@@ -56,7 +56,7 @@ SET ReceivedDate = DATETIME('{testDate:yyyy-MM-dd HH:mm:ss}');
             var timeZone = GetTestTimezone();
             var testDate = new DateTime(2021, 1, 4, 10, 0, 0, DateTimeKind.Utc);
 
-            using (new FakeLocalTimeZone(TimeZoneInfo.FindSystemTimeZoneById(timeZone.Id)))
+            using (new FakeLocalTimeZone(GetTimeZoneInfo(timeZone)))
             {
                 using var context = new Smtp4devDbContext(_sqlLiteForTesting.ContextOptions);
                 context.Messages.Add(new Message {From = "test"});

--- a/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
+++ b/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
@@ -13,12 +13,8 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="MailKit" Version="2.13.0" />
     <PackageReference Include="MedallionShell" Version="1.6.2" />
-
-
     <PackageReference Include="ReflectionMagic" Version="4.1.0" />
-
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="92.0.4515.10700" />

--- a/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
+++ b/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
@@ -13,11 +13,15 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="MailKit" Version="2.13.0" />
     <PackageReference Include="MedallionShell" Version="1.6.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+
+
     <PackageReference Include="ReflectionMagic" Version="4.1.0" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="90.0.4430.2400" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="92.0.4515.10700" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
+++ b/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
@@ -10,9 +10,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="MailKit" Version="2.13.0" />
     <PackageReference Include="MedallionShell" Version="1.6.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="ReflectionMagic" Version="4.1.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="90.0.4430.2400" />

--- a/Rnwood.Smtp4dev/ClientApp/package-lock.json
+++ b/Rnwood.Smtp4dev/ClientApp/package-lock.json
@@ -14144,9 +14144,9 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
-      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==",
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
       "dev": true
     },
     "vue-class-component": {
@@ -14329,9 +14329,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
-      "integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
+      "integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",

--- a/Rnwood.Smtp4dev/ClientApp/package.json
+++ b/Rnwood.Smtp4dev/ClientApp/package.json
@@ -37,11 +37,11 @@
     "srcdoc-polyfill": "^1.0.0",
     "ts-debounce": "^3.0.0",
     "typescript": "~4.3.5",
-    "vue": "^2.6.12",
+    "vue": "^2.6.14",
     "vue-class-component": "^7.2.6",
     "vue-property-decorator": "^9.1.2",
     "vue-router": "^3.5.1",
-    "vue-template-compiler": "^2.6.12",
+    "vue-template-compiler": "^2.6.14",
     "vue2-ace-editor": "0.0.15"
   },
   "eslintConfig": {

--- a/Rnwood.Smtp4dev/Data/Smtp4devDbContext.cs
+++ b/Rnwood.Smtp4dev/Data/Smtp4devDbContext.cs
@@ -6,8 +6,14 @@ namespace Rnwood.Smtp4dev.Data
     public class Smtp4devDbContext : DbContext
     {
         public Smtp4devDbContext(DbContextOptions<Smtp4devDbContext> options)
-        : base(options)
+            : base(options)
         {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            UtcDateTimeValueConverter.Apply(modelBuilder);
+            base.OnModelCreating(modelBuilder);
         }
 
         public DbSet<Message> Messages { get; set; }
@@ -15,6 +21,4 @@ namespace Rnwood.Smtp4dev.Data
 
         public DbSet<ImapState> ImapState { get; set; }
     }
-
 }
-

--- a/Rnwood.Smtp4dev/Data/UtcDateTimeValueConverter.cs
+++ b/Rnwood.Smtp4dev/Data/UtcDateTimeValueConverter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace Rnwood.Smtp4dev.Data
+{
+    public class UtcDateTimeValueConverter
+    {
+        public static void Apply(ModelBuilder modelBuilder)
+        {
+            var dateTimeConverter = new ValueConverter<DateTime, DateTime>(
+                v => v.ToUniversalTime(),
+                v => DateTime.SpecifyKind(v, DateTimeKind.Utc));
+
+            var nullableDateTimeConverter = new ValueConverter<DateTime?, DateTime?>(
+                v => v.HasValue ? v.Value.ToUniversalTime() : v,
+                v => v.HasValue ? DateTime.SpecifyKind(v.Value, DateTimeKind.Utc) : v);
+
+            foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            {
+                if (entityType.IsKeyless)
+                {
+                    continue;
+                }
+
+                foreach (var property in entityType.GetProperties())
+                {
+                    if (property.ClrType == typeof(DateTime))
+                    {
+                        property.SetValueConverter(dateTimeConverter);
+                    }
+                    else if (property.ClrType == typeof(DateTime?))
+                    {
+                        property.SetValueConverter(nullableDateTimeConverter);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Rnwood.Smtp4dev/Migrations/20210731045851_UTCTimeMigration.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210731045851_UTCTimeMigration.Designer.cs
@@ -2,16 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Rnwood.Smtp4dev.Data;
-using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Migrations
 {
     [DbContext(typeof(Smtp4devDbContext))]
-    partial class Smtp4devDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210731045851_UTCTimeMigration")]
+    partial class UTCTimeMigration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -120,6 +121,8 @@ namespace Rnwood.Smtp4dev.Migrations
                     b.HasOne("Rnwood.Smtp4dev.DbModel.Session", "Session")
                         .WithMany()
                         .HasForeignKey("SessionId");
+
+                    b.Navigation("Session");
                 });
 #pragma warning restore 612, 618
         }

--- a/Rnwood.Smtp4dev/Migrations/20210731045851_UTCTimeMigration.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210731045851_UTCTimeMigration.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Rnwood.Smtp4dev.Migrations
+{
+    public partial class UTCTimeMigration : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(CreateUpdateToUtcRawSql());
+        }
+
+        public static string CreateUpdateToUtcRawSql()
+        {
+            TimeZoneInfo tz = TimeZoneInfo.Local;
+            var offset = tz.GetUtcOffset(DateTime.Now.ToLocalTime());
+            return @$"
+Update Messages
+set ReceivedDate = DATETIME(ReceivedDate, '{-offset.TotalMinutes} minutes');
+
+Update Sessions
+set StartDate = DATETIME(StartDate, '{-offset.TotalMinutes} minutes'),
+EndDate = DATETIME(EndDate, '{-offset.TotalMinutes} minutes');
+";
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
**EDIT**

* Ensure all dates are converted to UTC before persisting by configuring DateTime properties with ValueConverters to convert to UTC.
* Observed that responses in JSON will have the 'Z' suffix noting the times are in UTC Kind. Front end client appears to render in local time.
 * EF Migration step to convert existing data to UTC added.

Relates to #807 