### PR TITLE
feat (Config/IMAP): Explicit config to enable/disable IMAP server 

### DIFF
--- a/Rnwood.Smtp4dev/CommandLineParser.cs
+++ b/Rnwood.Smtp4dev/CommandLineParser.cs
@@ -37,6 +37,7 @@ namespace Rnwood.Smtp4dev
                 { "relaypassword=", "The password for the SMTP server used to relay messages", data => map.Add(data, x=> x.RelayOptions.Password) },
                 { "relaytlsmode=",  "Sets the TLS mode when connecting to relay SMTP server. See: http://www.mimekit.net/docs/html/T_MailKit_Security_SecureSocketOptions.htm", data => map.Add(data, x=> x.RelayOptions.TlsMode) },
                 { "imapport=", "Specifies the port the IMAP server will listen on - allows standard email clients to view/retrieve messages", data => map.Add(data, x=> x.ServerOptions.ImapPort) },
+                { "imapserverenabled=", "Boolean to determine if IMAP server should start, default is true", data => map.Add(data, x=>x.ServerOptions.ImapServerEnabled)},
                 { "nousersettings", "Skip loading of appsetttings.json file in %APPDATA%", data => map.Add((data !=null).ToString(), x=> x.NoUserSettings) },
                 { "debugsettings", "Prints out most settings values on startup", data => map.Add((data !=null).ToString(), x=> x.DebugSettings) },
                 { "recreatedb", "Recreates the DB on startup if it already exists", data => map.Add((data !=null).ToString(), x=> x.ServerOptions.RecreateDb) }

--- a/Rnwood.Smtp4dev/Server/ImapServer.cs
+++ b/Rnwood.Smtp4dev/Server/ImapServer.cs
@@ -60,9 +60,15 @@ namespace Rnwood.Smtp4dev.Server
 
         public void TryStart()
         {
+            if (!serverOptions.CurrentValue.ImapServerEnabled)
+            {
+                log.Information("IMAP Server disabled");
+                return;
+            }
+
             if (!serverOptions.CurrentValue.ImapPort.HasValue)
             {
-                log.Information("IMAP server disabled");
+                log.Information("IMAP server disabled, no ImapPort specified");
                 return;
             }
 

--- a/Rnwood.Smtp4dev/Server/ServerOptions.cs
+++ b/Rnwood.Smtp4dev/Server/ServerOptions.cs
@@ -22,6 +22,8 @@ namespace Rnwood.Smtp4dev.Server
 
         public int? ImapPort { get; set; } = 143;
 
+        public bool ImapServerEnabled { get; set; } = true;
+
         public bool RecreateDb { get; set; }
     }
 }

--- a/Rnwood.Smtp4dev/appsettings.json
+++ b/Rnwood.Smtp4dev/appsettings.json
@@ -48,7 +48,10 @@
     "TlsCertificate": "",
 
     //Specifies the port the IMAP server will listen on - allows standard email clients to view/retrieve messages
-    "ImapPort": 143
+    "ImapPort": 143,
+
+    // Explicity enable/disable IMAP server, default is true
+    "ImapServerEnabled":  true
   },
 
   "RelayOptions": {


### PR DESCRIPTION
Explicit config option to disable/enable IMAP server feature rather than relying on the omission of IMAP port.   
By default set to true to match existing behaviour.