### PR TITLE
feat: (RelayMessages): Mark emails that have been relayed. (#774)

### DIFF
--- a/Rnwood.Smtp4dev.Tests/Controllers/RelayMessageTests.cs
+++ b/Rnwood.Smtp4dev.Tests/Controllers/RelayMessageTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using MimeKit;
+using NSubstitute;
+using Rnwood.Smtp4dev.ApiModel;
+using Rnwood.Smtp4dev.Controllers;
+using Rnwood.Smtp4dev.Data;
+using Rnwood.Smtp4dev.Server;
+using Rnwood.Smtp4dev.Tests.DBMigrations.Helpers;
+using Xunit;
+using Message = Rnwood.Smtp4dev.DbModel.Message;
+
+namespace Rnwood.Smtp4dev.Tests.Controllers
+{
+    public class MessagesControllerTests : IDisposable
+    {
+        private readonly MessagesController controller;
+        private readonly IMessagesRepository messagesRepository;
+        private readonly ISmtp4devServer server;
+        private readonly Smtp4devDbContext context;
+
+        public MessagesControllerTests()
+        {
+            messagesRepository = Substitute.For<IMessagesRepository>();
+            server = Substitute.For<ISmtp4devServer>();
+            controller = new MessagesController(messagesRepository, server);
+            var sqlLiteForTesting = new SqliteInMemory();
+            context = new Smtp4devDbContext(sqlLiteForTesting.ContextOptions);
+            InitRepo();
+            messagesRepository.GetMessages(Arg.Any<bool>())
+                .Returns(context.Messages);
+            messagesRepository.DbContext.Returns(context);
+        }
+
+        [Fact]
+        public void CanRelayMessageAndPersistResult()
+        {
+            // setup
+            var messageId = GetData().First().Id;
+
+            server.TryRelayMessage(Arg.Any<DbModel.Message>(), Arg.Any<MailboxAddress[]>()).Returns(new RelayResult(GetData().First())
+            {
+                RelayRecipients = new List<RelayRecipientResult>()
+                    { new RelayRecipientResult { Email = "relay@blah.com", RelayDate = DateTime.UtcNow } }
+            });
+
+            // act
+            var result = controller.RelayMessage(messageId,
+                new MessageRelayOptions() { OverrideRecipientAddresses = new[] { "test@foo.bar" } });
+
+            // expect ok result
+            result.Should().BeOfType<OkResult>();
+
+            var relay = context.MessageRelays.FirstOrDefault(mr => mr.MessageId == messageId);
+            //expect MessageRelay persisted. 
+            relay.Should().NotBeNull();
+        }
+
+        private IEnumerable<Message> GetData()
+        {
+            return new List<Message>() { new Message() { Id = new Guid("7476cf62-03e4-4d58-93ac-1cd143ba8653") } };
+        }
+
+        private void InitRepo()
+        {
+            context.Messages.AddRange(GetData());
+            context.SaveChanges();
+        }
+
+        public void Dispose()
+        {
+            context?.Dispose();
+        }
+    }
+}

--- a/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
+++ b/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
@@ -13,12 +13,14 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="MailKit" Version="2.13.0" />
     <PackageReference Include="MedallionShell" Version="1.6.2" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="ReflectionMagic" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="92.0.4515.10700" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.12" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/Rnwood.Smtp4dev.Tests/TestMessagesRepository.cs
+++ b/Rnwood.Smtp4dev.Tests/TestMessagesRepository.cs
@@ -23,7 +23,9 @@ namespace Rnwood.Smtp4dev.Tests
 			return Task.CompletedTask;
 		}
 
-		public Task DeleteMessage(Guid id)
+        public Smtp4devDbContext DbContext => throw new NotImplementedException();
+
+        public Task DeleteMessage(Guid id)
 		{
 			Messages.RemoveAll(m => m.Id == id);
 			return Task.CompletedTask;

--- a/Rnwood.Smtp4dev/ApiModel/MessageSummary.cs
+++ b/Rnwood.Smtp4dev/ApiModel/MessageSummary.cs
@@ -1,9 +1,4 @@
-﻿using MimeKit;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System;
 
 namespace Rnwood.Smtp4dev.ApiModel
 {
@@ -18,7 +13,10 @@ namespace Rnwood.Smtp4dev.ApiModel
             Subject = dbMessage.Subject;
             AttachmentCount = dbMessage.AttachmentCount;
             IsUnread = dbMessage.IsUnread;
+            IsRelayed = dbMessage.Relays.Count > 0;
         }
+
+        public bool IsRelayed { get; set; }
 
         public Guid Id { get; set; }
 
@@ -32,6 +30,6 @@ namespace Rnwood.Smtp4dev.ApiModel
 
         public bool IsUnread { get; set; }
 
-        string ICacheByKey.CacheKey => Id.ToString() + IsUnread.ToString();
+        string ICacheByKey.CacheKey => Id.ToString() + IsUnread + IsRelayed;
     }
 }

--- a/Rnwood.Smtp4dev/ClientApp/src/ApiClient/MessageSummary.ts
+++ b/Rnwood.Smtp4dev/ClientApp/src/ApiClient/MessageSummary.ts
@@ -1,24 +1,30 @@
-﻿
+﻿export default class MessageSummary {
+  constructor(
+    id: string,
+    from: string,
+    to: string,
+    receivedDate: Date,
+    subject: string,
+    attachmentCount: number,
+    isUnread: boolean,
+    isRelayed: boolean,
+  ) {
+    this.id = id;
+    this.from = from;
+    this.to = to;
+    this.receivedDate = receivedDate;
+    this.subject = subject;
+    this.attachmentCount = attachmentCount;
+    this.isUnread = isUnread;
+    this.isRelayed = isRelayed;
+  }
 
-export default class MessageSummary {
- 
-    constructor(id: string, from: string, to: string, receivedDate: Date, subject: string, attachmentCount: number, isUnread: boolean, ) {
-         
-        this.id = id; 
-        this.from = from; 
-        this.to = to; 
-        this.receivedDate = receivedDate; 
-        this.subject = subject; 
-        this.attachmentCount = attachmentCount; 
-        this.isUnread = isUnread;
-    }
-
-     
-    id: string; 
-    from: string; 
-    to: string; 
-    receivedDate: Date; 
-    subject: string; 
-    attachmentCount: number; 
-    isUnread: boolean;
+  id: string;
+  from: string;
+  to: string;
+  receivedDate: Date;
+  subject: string;
+  attachmentCount: number;
+  isUnread: boolean;
+  isRelayed: boolean;
 }

--- a/Rnwood.Smtp4dev/ClientApp/src/components/app/app.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/app/app.vue
@@ -9,6 +9,8 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component } from "vue-property-decorator";
+import '@fortawesome/fontawesome-free/css/all.css'
+import '@fortawesome/fontawesome-free/js/all.js'
 
 @Component({})
 export default class AppComponent extends Vue {}
@@ -24,7 +26,5 @@ $--button-small-padding-vertical: 7px;
 $--button-small-padding-horizontal: 12px;
 $--input-small-padding-vertical: 7px;
 
-
 @import "~element-ui/packages/theme-chalk/src/index";
-
 </style>

--- a/Rnwood.Smtp4dev/ClientApp/src/components/messagelist.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/messagelist.vue
@@ -1,367 +1,446 @@
 ﻿<template>
-    <div class="messagelist">
-        <div class="toolbar">
+  <div class="messagelist">
+    <div class="toolbar">
+      <confirmationdialog
+        v-on:confirm="clear"
+        always-key="deleteAllMessages"
+        message="Are you sure you want to delete all messages?"
+      >
+        <el-button icon="el-icon-close" title="Clear"></el-button>
+      </confirmationdialog>
 
-            <confirmationdialog v-on:confirm="clear"
-                                always-key="deleteAllMessages"
-                                message="Are you sure you want to delete all messages?">
-                <el-button icon="el-icon-close" title="Clear"></el-button>
-            </confirmationdialog>
+      <el-button
+        icon="el-icon-delete"
+        v-on:click="deleteSelected"
+        :disabled="!selectedmessage"
+        title="Delete"
+      ></el-button>
+      <el-button
+        icon="el-icon-refresh"
+        v-on:click="refresh"
+        :disabled="loading"
+        title="Refresh"
+      ></el-button>
 
-            <el-button icon="el-icon-delete"
-                       v-on:click="deleteSelected"
-                       :disabled="!selectedmessage" title="Delete"></el-button>
-            <el-button icon="el-icon-refresh"
-                       v-on:click="refresh"
-                       :disabled="loading" title="Refresh"></el-button>
+      <el-button
+        v-on:click="relaySelected"
+        icon="el-icon-d-arrow-right"
+        :disabled="!selectedmessage || !isRelayAvailable"
+        :loading="isRelayInProgress"
+        title="Relay"
+      ></el-button>
 
-            <el-button v-on:click="relaySelected" icon="el-icon-d-arrow-right" :disabled="!selectedmessage || !isRelayAvailable" :loading="isRelayInProgress" title="Relay"></el-button>
-
-            <el-input v-model="searchTerm"
-                      clearable
-                      placeholder="Search"
-                      prefix-icon="el-icon-search"
-                      style="float: right; width: 35%; min-width: 150px;" />
-        </div>
-
-        <el-alert v-if="error" type="error" title="Error" show-icon>
-            {{error.message}}
-            <el-button v-on:click="refresh">Retry</el-button>
-        </el-alert>
-
-        <el-table :data="filteredMessages"
-                  v-loading="loading"
-                  :empty-text="emptyText"
-                  highlight-current-row
-                  @current-change="handleCurrentChange"
-                  @sort-change="sort"
-                  :default-sort="{prop: 'receivedDate', order: 'descending'}"
-                  class="table"
-                  type="selection"
-                  reserve-selection="true"
-                  row-key="id"
-                  :row-class-name="getRowClass"
-                  ref="table"
-                  stripe>
-            <el-table-column property="receivedDate"
-                             label="Received"
-                             width="180"
-                             sortable="custom"
-                             :formatter="formatDate"></el-table-column>
-            <el-table-column property="from" label="From" width="120" sortable="custom"></el-table-column>
-            <el-table-column property="to" label="To" width="120" sortable="custom"></el-table-column>
-            <el-table-column property="subject" label="Subject" sortable="custom">
-                <template slot-scope="scope">
-                    {{scope.row.subject}}
-                    <i class="el-icon-paperclip"
-                       v-if="scope.row.attachmentCount"
-                       :title="scope.row.attachmentCount + ' attachments'"></i>
-                </template>
-            </el-table-column>
-        </el-table>
+      <el-input
+        v-model="searchTerm"
+        clearable
+        placeholder="Search"
+        prefix-icon="el-icon-search"
+        style="float: right; width: 35%; min-width: 150px"
+      />
     </div>
+
+    <el-alert v-if="error" type="error" title="Error" show-icon>
+      {{ error.message }}
+      <el-button v-on:click="refresh">Retry</el-button>
+    </el-alert>
+
+    <el-table
+      :data="filteredMessages"
+      v-loading="loading"
+      :empty-text="emptyText"
+      highlight-current-row
+      @current-change="handleCurrentChange"
+      @sort-change="sort"
+      :default-sort="{ prop: 'receivedDate', order: 'descending' }"
+      class="table"
+      type="selection"
+      reserve-selection="true"
+      row-key="id"
+      :row-class-name="getRowClass"
+      ref="table"
+      stripe
+    >
+      <el-table-column
+        property="receivedDate"
+        label="Received"
+        width="180"
+        sortable="custom"
+        :formatter="formatDate"
+      ></el-table-column>
+      <el-table-column
+        property="from"
+        label="From"
+        width="120"
+        sortable="custom"
+      ></el-table-column>
+      <el-table-column
+        property="to"
+        label="To"
+        width="120"
+        sortable="custom"
+      ></el-table-column>
+      <el-table-column
+        property="isRelayed"
+        label=""
+        width="28"
+        :formatter="cellValueRenderer"
+      >
+        <template slot-scope="scope">
+          <div v-if="scope.row.isRelayed">
+            <el-tooltip
+              effect="light"
+              content="Message has been relayed"
+              placement="top-start"
+            >
+              <span> <i class="fas fa-share-square"></i></span>
+            </el-tooltip>
+          </div>
+        </template>
+      </el-table-column>
+      <el-table-column property="subject" label="Subject" sortable="custom">
+        <template slot-scope="scope">
+          {{ scope.row.subject }}
+          <i
+            class="el-icon-paperclip"
+            v-if="scope.row.attachmentCount"
+            :title="scope.row.attachmentCount + ' attachments'"
+          ></i>
+        </template>
+      </el-table-column>
+    </el-table>
+  </div>
 </template>
 <script lang="ts">
-    import { Component, Watch, Prop } from "vue-property-decorator";
-    import Vue from "vue";
-    import { DefaultSortOptions, ElTable } from "element-ui/types/table";
-    import MessagesController from "../ApiClient/MessagesController";
-    import MessageSummary from "../ApiClient/MessageSummary";
-    import * as moment from 'moment';
-    import HubConnectionManager from "../HubConnectionManager";
-    import sortedArraySync from "../sortedArraySync";
-    import { Mutex } from "async-mutex";
-    import MessageNotificationManager from "../MessageNotificationManager";
-    import { debounce } from "ts-debounce";
+import { Component, Watch, Prop } from "vue-property-decorator";
+import Vue from "vue";
+import { DefaultSortOptions, ElTable } from "element-ui/types/table";
+import MessagesController from "../ApiClient/MessagesController";
+import MessageSummary from "../ApiClient/MessageSummary";
+import * as moment from "moment";
+import HubConnectionManager from "../HubConnectionManager";
+import sortedArraySync from "../sortedArraySync";
+import { Mutex } from "async-mutex";
+import MessageNotificationManager from "../MessageNotificationManager";
+import { debounce } from "ts-debounce";
 
-    import ConfirmationDialog from "@/components/confirmationdialog.vue";
-    import { MessageBoxInputData } from 'element-ui/types/message-box';
-    import ServerController from '../ApiClient/ServerController';
-    import { mapOrder } from '@/components/utils/mapOrder';
+import ConfirmationDialog from "@/components/confirmationdialog.vue";
+import { MessageBoxInputData } from "element-ui/types/message-box";
+import ServerController from "../ApiClient/ServerController";
+import { mapOrder } from "@/components/utils/mapOrder";
 
-    @Component({
-        components: {
-            confirmationdialog: ConfirmationDialog
+@Component({
+  components: {
+    confirmationdialog: ConfirmationDialog,
+  },
+})
+export default class MessageList extends Vue {
+  constructor() {
+    super();
+  }
+
+  private selectedSortDescending: boolean = true;
+  private selectedSortColumn: string = "receivedDate";
+
+  @Prop({ default: null })
+  connection: HubConnectionManager | null = null;
+
+  messages: MessageSummary[] = [];
+  filteredMessages: MessageSummary[] = [];
+
+  isRelayInProgress: boolean = false;
+  isRelayAvailable: boolean = false;
+
+  emptyText: string = "No messages";
+  error: Error | null = null;
+  selectedmessage: MessageSummary | null = null;
+  searchTerm: string = "";
+  private loading: boolean = true;
+  private messageNotificationManager = new MessageNotificationManager(
+    (message) => {
+      this.selectMessage(message);
+      this.handleCurrentChange(message);
+    }
+  );
+
+  selectMessage(message: MessageSummary) {
+    (<ElTable>this.$refs.table).setCurrentRow(message);
+    this.handleCurrentChange(message);
+  }
+
+  handleCurrentChange(message: MessageSummary | null) {
+    this.selectedmessage = message;
+    this.$emit("selected-message-changed", message);
+  }
+
+  cellValueRenderer(
+    row: { [x: string]: any },
+    column: { property: string | number },
+    cellValue: any,
+    index: any
+  ) {
+    let value = cellValue;
+    if (typeof row[column.property] === "boolean") {
+      value = String(cellValue);
+    }
+    return value;
+  }
+
+  formatDate(row: number, column: number, cellValue: Date): string {
+    return (<any>moment)(cellValue).format("YYYY-MM-DD HH:mm:ss");
+  }
+
+  getRowClass(event: { row: MessageSummary }): string {
+    return event.row.isUnread ? "unread" : "read";
+  }
+
+  async relaySelected() {
+    if (this.selectedmessage == null) {
+      return;
+    }
+
+    var msg = this.selectedmessage;
+
+    let emails: string[];
+
+    try {
+      let dialogResult = <MessageBoxInputData>await this.$prompt(
+        "Email address(es) to relay to (separate multiple with ,)",
+        "Relay Message",
+        {
+          confirmButtonText: "OK",
+          inputValue: this.selectedmessage.to,
+          cancelButtonText: "Cancel",
+          inputPattern: /[^, ]+(, *[^, ]+)*/,
+          inputErrorMessage: "Invalid email addresses",
         }
-    })
-    export default class MessageList extends Vue {
-        constructor() {
-            super();
-        }
+      );
 
-        private selectedSortDescending: boolean = true;
-        private selectedSortColumn: string = "receivedDate";
+      emails = (<string>dialogResult.value).split(",").map((e) => e.trim());
+    } catch {
+      return;
+    }
 
+    try {
+      this.isRelayInProgress = true;
+      await new MessagesController().relayMessage(this.selectedmessage.id, {
+        overrideRecipientAddresses: emails,
+      });
 
-        @Prop({ default: null })
-        connection: HubConnectionManager | null = null;
+      this.$notify.success({
+        title: "Relay Message Success",
+        message: "Completed OK",
+      });
+    } catch (e) {
+      var message = e.response?.data?.detail ?? e.sessage;
 
-        messages: MessageSummary[] = [];
-        filteredMessages: MessageSummary[] = [];
+      this.$notify.error({ title: "Relay Message Failed", message: message });
+    } finally {
+      this.isRelayInProgress = false;
+    }
+  }
 
-        isRelayInProgress: boolean = false;
-        isRelayAvailable: boolean = false;
+  async deleteSelected() {
+    if (this.selectedmessage == null) {
+      return;
+    }
 
-        emptyText: string = "No messages";
-        error: Error | null = null;
-        selectedmessage: MessageSummary | null = null;
-        searchTerm: string = "";
-        private loading: boolean = true;
-        private messageNotificationManager = new MessageNotificationManager(
-            message => {
-                this.selectMessage(message);
-                this.handleCurrentChange(message);
-            }
-        );
+    this.loading = true;
 
-        selectMessage(message: MessageSummary) {
-            (<ElTable>this.$refs.table).setCurrentRow(message);
-            this.handleCurrentChange(message);
-        }
+    let messageToDelete = this.selectedmessage;
 
-        handleCurrentChange(message: MessageSummary | null) {
-            this.selectedmessage = message;
-            this.$emit("selected-message-changed", message);
-        }
+    let nextIndex = this.filteredMessages.indexOf(messageToDelete) + 1;
+    if (nextIndex < this.filteredMessages.length) {
+      this.selectMessage(this.filteredMessages[nextIndex]);
+    }
 
-        formatDate(
-            row: number,
-            column: number,
-            cellValue: Date
-        ): string {
-            return (<any>moment)(cellValue).format("YYYY-MM-DD HH:mm:ss");
-        }
+    try {
+      await new MessagesController().delete(messageToDelete.id);
+      await this.refresh();
+    } catch (e) {
+      this.$notify.error({
+        title: "Delete Message Failed",
+        message: e.message,
+      });
+    } finally {
+      this.loading = false;
+    }
+  }
 
-        getRowClass(event: { row: MessageSummary }): string {
-            return event.row.isUnread ? "unread" : "read";
-        }
+  async clear() {
+    try {
+      this.loading = true;
+      await new MessagesController().deleteAll();
+      await this.refresh();
+    } catch (e) {
+      this.$notify.error({
+        title: "Clear Messages Failed",
+        message: e.message,
+      });
+    } finally {
+      this.loading = false;
+    }
+  }
 
-        async relaySelected() {
-            if (this.selectedmessage == null) {
-                return;
-            }
+  @Watch("searchTerm")
+  doSearch() {
+    this.loading = true;
+    this.debouncedUpdateFilteredMessages();
+  }
 
-            var msg = this.selectedmessage;
+  debouncedUpdateFilteredMessages = debounce(this.updateFilteredMessages, 200);
 
-
-            let emails: string[];
-
-            try {
-
-                let dialogResult = <MessageBoxInputData>await this.$prompt('Email address(es) to relay to (separate multiple with ,)', 'Relay Message', {
-                    confirmButtonText: 'OK',
-                    inputValue: this.selectedmessage.to,
-                    cancelButtonText: 'Cancel',
-                    inputPattern: /[^, ]+(, *[^, ]+)*/,
-                    inputErrorMessage: 'Invalid email addresses'
-                });
-
-                emails = (<string>dialogResult.value).split(",").map(e => e.trim());
-            } catch {
-                return;
-            }
-
-            try {
-                this.isRelayInProgress = true;
-                await new MessagesController().relayMessage(this.selectedmessage.id, { overrideRecipientAddresses: emails });
-
-                this.$notify.success({ title: "Relay Message Success", message: "Completed OK" });
-            } catch (e) {
-                var message = e.response?.data?.detail ?? e.sessage;
-
-                this.$notify.error({ title: "Relay Message Failed", message: message });
-            } finally {
-                this.isRelayInProgress = false;
-            }
-        }
-
-        async deleteSelected() {
-            if (this.selectedmessage == null) {
-                return;
-            }
-
-            this.loading = true;
-
-            let messageToDelete = this.selectedmessage;
-
-            let nextIndex = this.filteredMessages.indexOf(messageToDelete) + 1;
-            if (nextIndex < this.filteredMessages.length) {
-                this.selectMessage(this.filteredMessages[nextIndex]);
-            }
-
-            try {
-                await new MessagesController().delete(messageToDelete.id);
-                await this.refresh();
-            } catch (e) {
-                this.$notify.error({ title: "Delete Message Failed", message: e.message });
-            } finally {
-                this.loading = false;
-            }
-        }
-
-        async clear() {
-            try {
-                this.loading = true;
-                await new MessagesController().deleteAll();
-                await this.refresh();
-            } catch (e) {
-                this.$notify.error({ title: "Clear Messages Failed", message: e.message });
-            } finally {
-                this.loading = false;
-            }
-        }
-
-        @Watch("searchTerm")
-        doSearch() {
-            this.loading = true;
-            this.debouncedUpdateFilteredMessages();
-        }
-
-        debouncedUpdateFilteredMessages = debounce(this.updateFilteredMessages, 200);
-
-        updateFilteredMessages() {
-
-            try {
-                this.loading = true;
-                if (this.searchTerm) {
-                    this.emptyText = "No messages matching '" + this.searchTerm + "'";
-                } else {
-                    this.emptyText = "No messages";
-                }
-
-                sortedArraySync(
-                    this.messages.filter(m => this.searchTermPredicate(m)
-                    ),
-                    this.filteredMessages,
-                    (a: MessageSummary, b: MessageSummary) => a.id == b.id,
-                    (sourceItem: MessageSummary, targetItem: MessageSummary) => {
-                        targetItem.isUnread = sourceItem.isUnread;
-                    }
-                );
-                
-                const sortedMessageIds = this.messages.map(m=>m.id);
-                this.filteredMessages = mapOrder(this.filteredMessages, sortedMessageIds, 'id');
-
-                if (!this.filteredMessages.some(m => this.selectedmessage != null && m.id == this.selectedmessage.id)) {
-                    this.handleCurrentChange(null);
-                }
-            } finally {
-                this.loading = false;
-            }
-        }
-
-      private searchTermPredicate(m: MessageSummary) {
-        return !this.searchTerm ||
-            (m.subject ? (m.subject.localeIndexOf(this.searchTerm, undefined, {
-              sensitivity: "base"
-            }) != -1 ) : false) ||
-            m.to.localeIndexOf(this.searchTerm, undefined, {
-              sensitivity: "base"
-            }) != -1 ||
-            m.from.localeIndexOf(this.searchTerm, undefined, {
-              sensitivity: "base"
-            }) != -1;
+  updateFilteredMessages() {
+    try {
+      this.loading = true;
+      if (this.searchTerm) {
+        this.emptyText = "No messages matching '" + this.searchTerm + "'";
+      } else {
+        this.emptyText = "No messages";
       }
 
-      private lastSort: string | null = null;
-        private lastSortDescending: boolean = false;
-        private mutex = new Mutex();
-
-        initialLoadDone = false;
-
-        async refresh(silent: boolean = false) {
-            var unlock = await this.mutex.acquire();
-
-            try {
-                this.error = null;
-                this.loading = !silent;
-
-
-                //Copy in case they are mutated during the async load below
-                let sortColumn = this.selectedSortColumn;
-                let sortDescending = this.selectedSortDescending;
-
-                let serverMessages = await new MessagesController().getSummaries(
-                    sortColumn,
-                    sortDescending
-                );
-
-                if (
-                    !this.lastSort ||
-                    this.lastSort != sortColumn ||
-                    this.lastSortDescending != sortDescending ||
-                    serverMessages.length == 0
-                ) {
-                    this.messages.splice(0, this.messages.length, ...serverMessages);
-                } else {
-                    sortedArraySync(
-                        serverMessages,
-                        this.messages,
-                        (a: MessageSummary, b: MessageSummary) => a.id == b.id,
-                        (sourceItem: MessageSummary, targetItem: MessageSummary) => {
-                            targetItem.isUnread = sourceItem.isUnread;
-                        }
-                    );
-                }
-
-                if (this.initialLoadDone) {
-                    this.messageNotificationManager.notifyMessages(this.messages);
-                } else {
-                    this.messageNotificationManager.setInitialMessages(this.messages);
-                }
-
-                this.updateFilteredMessages();
-
-                this.initialLoadDone = true;
-                this.lastSort = sortColumn;
-                this.lastSortDescending = this.selectedSortDescending;
-
-                this.isRelayAvailable = !!await (await new ServerController().getServer()).relayOptions.smtpServer;
-            } catch (e) {
-                this.error = e;
-            } finally {
-                this.loading = false;
-                unlock();
-            }
+      sortedArraySync(
+        this.messages.filter((m) => this.searchTermPredicate(m)),
+        this.filteredMessages,
+        (a: MessageSummary, b: MessageSummary) => a.id == b.id,
+        (sourceItem: MessageSummary, targetItem: MessageSummary) => {
+          targetItem.isUnread = sourceItem.isUnread;
         }
+      );
 
-        async sort(sortOptions: DefaultSortOptions) {
-            let descending: boolean = true;
-            if (sortOptions.order === "ascending") {
-                descending = false;
-            }
+      const sortedMessageIds = this.messages.map((m) => m.id);
+      this.filteredMessages = mapOrder(
+        this.filteredMessages,
+        sortedMessageIds,
+        "id"
+      );
 
-            if (
-                this.selectedSortColumn != sortOptions.prop ||
-                this.selectedSortDescending != descending
-            ) {
-                this.selectedSortColumn = sortOptions.prop || "receivedDate";
-                this.selectedSortDescending = descending;
-
-                await this.refresh();
-            }
-        }
-
-
-        async mounted() {
-            await this.refresh(false);
-        }
-
-        @Watch("connection")
-        async onConnectionChanged() {
-
-            if (this.connection) {
-                this.connection.on("messageschanged", async () => {
-                    await this.refresh(true);
-                });
-                this.connection.on("serverchanged", async () => {
-                    await this.refresh(true);
-                });
-                this.connection.addOnConnectedCallback(() => {
-                    this.refresh(true);
-                });
-            }
-        }
-
+      if (
+        !this.filteredMessages.some(
+          (m) => this.selectedmessage != null && m.id == this.selectedmessage.id
+        )
+      ) {
+        this.handleCurrentChange(null);
+      }
+    } finally {
+      this.loading = false;
     }
+  }
+
+  private searchTermPredicate(m: MessageSummary) {
+    return (
+      !this.searchTerm ||
+      (m.subject
+        ? m.subject.localeIndexOf(this.searchTerm, undefined, {
+            sensitivity: "base",
+          }) != -1
+        : false) ||
+      m.to.localeIndexOf(this.searchTerm, undefined, {
+        sensitivity: "base",
+      }) != -1 ||
+      m.from.localeIndexOf(this.searchTerm, undefined, {
+        sensitivity: "base",
+      }) != -1
+    );
+  }
+
+  private lastSort: string | null = null;
+  private lastSortDescending: boolean = false;
+  private mutex = new Mutex();
+
+  initialLoadDone = false;
+
+  async refresh(silent: boolean = false) {
+    var unlock = await this.mutex.acquire();
+
+    try {
+      this.error = null;
+      this.loading = !silent;
+
+      //Copy in case they are mutated during the async load below
+      let sortColumn = this.selectedSortColumn;
+      let sortDescending = this.selectedSortDescending;
+
+      let serverMessages = await new MessagesController().getSummaries(
+        sortColumn,
+        sortDescending
+      );
+
+      if (
+        !this.lastSort ||
+        this.lastSort != sortColumn ||
+        this.lastSortDescending != sortDescending ||
+        serverMessages.length == 0
+      ) {
+        this.messages.splice(0, this.messages.length, ...serverMessages);
+      } else {
+        sortedArraySync(
+          serverMessages,
+          this.messages,
+          (a: MessageSummary, b: MessageSummary) => a.id == b.id,
+          (sourceItem: MessageSummary, targetItem: MessageSummary) => {
+            targetItem.isUnread = sourceItem.isUnread;
+            targetItem.isRelayed = sourceItem.isRelayed;
+          }
+        );
+      }
+
+      if (this.initialLoadDone) {
+        this.messageNotificationManager.notifyMessages(this.messages);
+      } else {
+        this.messageNotificationManager.setInitialMessages(this.messages);
+      }
+
+      this.updateFilteredMessages();
+
+      this.initialLoadDone = true;
+      this.lastSort = sortColumn;
+      this.lastSortDescending = this.selectedSortDescending;
+
+      this.isRelayAvailable = !!(await (
+        await new ServerController().getServer()
+      ).relayOptions.smtpServer);
+    } catch (e) {
+      this.error = e;
+    } finally {
+      this.loading = false;
+      unlock();
+    }
+  }
+
+  async sort(sortOptions: DefaultSortOptions) {
+    let descending: boolean = true;
+    if (sortOptions.order === "ascending") {
+      descending = false;
+    }
+
+    if (
+      this.selectedSortColumn != sortOptions.prop ||
+      this.selectedSortDescending != descending
+    ) {
+      this.selectedSortColumn = sortOptions.prop || "receivedDate";
+      this.selectedSortDescending = descending;
+
+      await this.refresh();
+    }
+  }
+
+  async mounted() {
+    await this.refresh(false);
+  }
+
+  @Watch("connection")
+  async onConnectionChanged() {
+    if (this.connection) {
+      this.connection.on("messageschanged", async () => {
+        await this.refresh(true);
+      });
+      this.connection.on("serverchanged", async () => {
+        await this.refresh(true);
+      });
+      this.connection.addOnConnectedCallback(() => {
+        this.refresh(true);
+      });
+    }
+  }
+}
 </script>

--- a/Rnwood.Smtp4dev/Controllers/MessagesController.cs
+++ b/Rnwood.Smtp4dev/Controllers/MessagesController.cs
@@ -1,174 +1,176 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.Entity;
 using System.IO;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading.Tasks;
-
 using HtmlAgilityPack;
-
 using Microsoft.AspNetCore.Mvc;
-
 using Rnwood.Smtp4dev.ApiModel;
 using System.Linq.Dynamic.Core;
-
+using Microsoft.EntityFrameworkCore;
 using Message = Rnwood.Smtp4dev.DbModel.Message;
 using Rnwood.Smtp4dev.Server;
 using MimeKit;
 using Rnwood.Smtp4dev.Data;
+using Rnwood.Smtp4dev.DbModel;
 
 namespace Rnwood.Smtp4dev.Controllers
 {
-	[Route("api/[controller]")]
-	[ApiController]
-	[UseEtagFilterAttribute]
-	public class MessagesController : Controller
-	{
-		public MessagesController(IMessagesRepository messagesRepository, Smtp4devServer server)
-		{
-			this.messagesRepository = messagesRepository;
-			this.server = server;
-		}
-
-		private readonly IMessagesRepository messagesRepository;
-		private readonly Smtp4devServer server;
-
-		[HttpGet]
-
-		public IEnumerable<ApiModel.MessageSummary> GetSummaries(string sortColumn = "receivedDate", bool sortIsDescending = true)
-		{
-			return messagesRepository.GetMessages()
-			.OrderBy(sortColumn + (sortIsDescending ? " DESC" : ""))
-			.Select(m => new MessageSummary(m));
-		}
-
-		private Message GetDbMessage(Guid id)
+    [Route("api/[controller]")]
+    [ApiController]
+    [UseEtagFilterAttribute]
+    public class MessagesController : Controller
+    {
+        public MessagesController(IMessagesRepository messagesRepository, Smtp4devServer server)
         {
-			return messagesRepository.GetMessages().SingleOrDefault(m => m.Id == id) ?? throw new FileNotFoundException($"Message with id {id} was not found.");
-		}
+            this.messagesRepository = messagesRepository;
+            this.server = server;
+        }
 
-		[HttpGet("{id}")]
-		public ApiModel.Message GetMessage(Guid id)
-		{
-			return new ApiModel.Message(GetDbMessage(id));
-		}
+        private readonly IMessagesRepository messagesRepository;
+        private readonly Smtp4devServer server;
 
-		[HttpPost("{id}")]
-		public Task MarkMessageRead(Guid id)
-		{
-			return messagesRepository.MarkMessageRead(id);
-		}
+        [HttpGet]
+        public IEnumerable<MessageSummary> GetSummaries(string sortColumn = "receivedDate", bool sortIsDescending = true)
+        {
+            return messagesRepository.GetMessages(false).Include(m => m.Relays)
+                .OrderBy(sortColumn + (sortIsDescending ? " DESC" : ""))
+                .Select(m => new MessageSummary(m));
+        }
 
-		[HttpGet("{id}/download")]
-		[ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
+        private Message GetDbMessage(Guid id)
+        {
+            return messagesRepository.GetMessages(false).SingleOrDefault(m => m.Id == id) ??
+                   throw new FileNotFoundException($"Message with id {id} was not found.");
+        }
 
-		public FileStreamResult DownloadMessage(Guid id)
-		{
-			Message result = GetDbMessage(id);
-			return new FileStreamResult(new MemoryStream(result.Data), "message/rfc822") { FileDownloadName = $"{id}.eml" };
-		}
+        [HttpGet("{id}")]
+        public ApiModel.Message GetMessage(Guid id)
+        {
+            return new ApiModel.Message(GetDbMessage(id));
+        }
 
-		[HttpPost("{id}/relay")]
+        [HttpPost("{id}")]
+        public Task MarkMessageRead(Guid id)
+        {
+            return messagesRepository.MarkMessageRead(id);
+        }
 
-		public IActionResult RelayMessage(Guid id, [FromBody] MessageRelayOptions options)
-		{
-			Message message = GetDbMessage(id);
-            Dictionary<MailboxAddress, Exception> relayErrors = server.TryRelayMessage(message, options?.OverrideRecipientAddresses?.Length > 0 ? options?.OverrideRecipientAddresses.Select(a => MailboxAddress.Parse(a)).ToArray() : null);
+        [HttpGet("{id}/download")]
+        [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
+        public FileStreamResult DownloadMessage(Guid id)
+        {
+            Message result = GetDbMessage(id);
+            return new FileStreamResult(new MemoryStream(result.Data), "message/rfc822") { FileDownloadName = $"{id}.eml" };
+        }
 
-			if (relayErrors.Any())
-			{
-				string relayErrorSummary = string.Join(". ", relayErrors.Select(e => e.Key.Address + ": " + e.Value.Message));
-				return Problem("Failed to relay to recipients: " + relayErrorSummary);
-			}
+        [HttpPost("{id}/relay")]
+        public IActionResult RelayMessage(Guid id, [FromBody] MessageRelayOptions options)
+        {
+            Message message = GetDbMessage(id);
+            var relayResult = server.TryRelayMessage(message,
+                options?.OverrideRecipientAddresses?.Length > 0
+                    ? options?.OverrideRecipientAddresses.Select(a => MailboxAddress.Parse(a)).ToArray()
+                    : null);
 
-			return Ok();
-		}
+            if (relayResult.Exceptions.Any())
+            {
+                string relayErrorSummary = string.Join(". ", relayResult.Exceptions.Select(e => e.Key.Address + ": " + e.Value.Message));
+                return Problem("Failed to relay to recipients: " + relayErrorSummary);
+            }
+            if (relayResult.WasRelayed)
+            {
+                foreach (var relay in relayResult.RelayRecipients)
+                {
+                    message.AddRelay(new MessageRelay { SendDate = relay.RelayDate, To = relay.Email });
+                }
+                messagesRepository.DbContext.SaveChanges();
+            }
+            return Ok();
+        }
 
-		[HttpGet("{id}/part/{partid}/content")]
-		[ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
-		public FileStreamResult GetPartContent(Guid id, string partid)
-		{
-			return ApiModel.Message.GetPartContent(GetMessage(id), partid);
-		}
+        [HttpGet("{id}/part/{partid}/content")]
+        [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
+        public FileStreamResult GetPartContent(Guid id, string partid)
+        {
+            return ApiModel.Message.GetPartContent(GetMessage(id), partid);
+        }
 
-		[HttpGet("{id}/part/{partid}/source")]
-		[ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
-		public string GetPartSource(Guid id, string partid)
-		{
-			return ApiModel.Message.GetPartContentAsText(GetMessage(id), partid);
-		}
+        [HttpGet("{id}/part/{partid}/source")]
+        [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
+        public string GetPartSource(Guid id, string partid)
+        {
+            return ApiModel.Message.GetPartContentAsText(GetMessage(id), partid);
+        }
 
-		[HttpGet("{id}/part/{partid}/raw")]
-		[ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
-		public string GetPartSourceRaw(Guid id, string partid)
-		{
-			return ApiModel.Message.GetPartSource(GetMessage(id), partid);
-		}
+        [HttpGet("{id}/part/{partid}/raw")]
+        [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
+        public string GetPartSourceRaw(Guid id, string partid)
+        {
+            return ApiModel.Message.GetPartSource(GetMessage(id), partid);
+        }
 
-		[HttpGet("{id}/raw")]
-		[ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
-		public string GetMessageSourceRaw(Guid id)
-		{
-			ApiModel.Message message = GetMessage(id);
-			return System.Text.Encoding.UTF8.GetString(message.Data);
-		}
+        [HttpGet("{id}/raw")]
+        [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
+        public string GetMessageSourceRaw(Guid id)
+        {
+            ApiModel.Message message = GetMessage(id);
+            return System.Text.Encoding.UTF8.GetString(message.Data);
+        }
 
-		[HttpGet("{id}/source")]
-		[ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
-		public string GetMessageSource(Guid id)
-		{
-			ApiModel.Message message = GetMessage(id);
-			return message.MimeMessage.ToString();
-		}
+        [HttpGet("{id}/source")]
+        [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
+        public string GetMessageSource(Guid id)
+        {
+            ApiModel.Message message = GetMessage(id);
+            return message.MimeMessage.ToString();
+        }
 
-		[HttpGet("{id}/html")]
-		[ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
-		public string GetMessageHtml(Guid id)
-		{
-			ApiModel.Message message = GetMessage(id);
+        [HttpGet("{id}/html")]
+        [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 31556926)]
+        public string GetMessageHtml(Guid id)
+        {
+            ApiModel.Message message = GetMessage(id);
 
-			string html = message.MimeMessage?.HtmlBody;
+            string html = message.MimeMessage?.HtmlBody;
 
-			if (html == null)
-			{
-				html = "<pre>" + HtmlAgilityPack.HtmlDocument.HtmlEncode(message.MimeMessage?.TextBody ?? "") + "</pre>";
-			}
+            if (html == null)
+            {
+                html = "<pre>" + HtmlAgilityPack.HtmlDocument.HtmlEncode(message.MimeMessage?.TextBody ?? "") + "</pre>";
+            }
 
-	
-			HtmlDocument doc = new HtmlDocument();
-			doc.LoadHtml(html);
 
-			
+            HtmlDocument doc = new HtmlDocument();
+            doc.LoadHtml(html);
 
-			HtmlNodeCollection imageElements = doc.DocumentNode.SelectNodes("//img[starts-with(@src, 'cid:')]");
 
-			if (imageElements != null)
-			{
-				foreach (HtmlNode imageElement in imageElements)
-				{
-					string cid = imageElement.Attributes["src"].Value.Replace("cid:", "", StringComparison.OrdinalIgnoreCase);
+            HtmlNodeCollection imageElements = doc.DocumentNode.SelectNodes("//img[starts-with(@src, 'cid:')]");
 
-					var part = message.Parts.Flatten(p => p.ChildParts).SingleOrDefault(p => p.ContentId == cid);
+            if (imageElements != null)
+            {
+                foreach (HtmlNode imageElement in imageElements)
+                {
+                    string cid = imageElement.Attributes["src"].Value.Replace("cid:", "", StringComparison.OrdinalIgnoreCase);
 
-					imageElement.Attributes["src"].Value = $"api/Messages/{id.ToString()}/part/{part?.Id ?? "notfound"}/content";
-				}
-			}
+                    var part = message.Parts.Flatten(p => p.ChildParts).SingleOrDefault(p => p.ContentId == cid);
 
-			return doc.DocumentNode.OuterHtml;
-		}
+                    imageElement.Attributes["src"].Value = $"api/Messages/{id.ToString()}/part/{part?.Id ?? "notfound"}/content";
+                }
+            }
 
-		[HttpDelete("{id}")]
-		public async Task Delete(Guid id)
-		{
-			await messagesRepository.DeleteMessage(id);
-		}
+            return doc.DocumentNode.OuterHtml;
+        }
 
-		[HttpDelete("*")]
-		public async Task DeleteAll()
-		{
-			await messagesRepository.DeleteAllMessages();
-		}
+        [HttpDelete("{id}")]
+        public async Task Delete(Guid id)
+        {
+            await messagesRepository.DeleteMessage(id);
+        }
 
-	}
+        [HttpDelete("*")]
+        public async Task DeleteAll()
+        {
+            await messagesRepository.DeleteAllMessages();
+        }
+    }
 }

--- a/Rnwood.Smtp4dev/Controllers/ServerController.cs
+++ b/Rnwood.Smtp4dev/Controllers/ServerController.cs
@@ -20,7 +20,7 @@ namespace Rnwood.Smtp4dev.Controllers
     [ApiController]
     public class ServerController : Controller
     {
-        public ServerController(Smtp4devServer server, ImapServer imapServer, IOptionsMonitor<ServerOptions> serverOptions, IOptionsMonitor<RelayOptions> relayOptions)
+        public ServerController(ISmtp4devServer server, ImapServer imapServer, IOptionsMonitor<ServerOptions> serverOptions, IOptionsMonitor<RelayOptions> relayOptions)
         {
             this.server = server;
             this.imapServer = imapServer;
@@ -29,7 +29,7 @@ namespace Rnwood.Smtp4dev.Controllers
         }
 
 
-        private Smtp4devServer server;
+        private ISmtp4devServer server;
         private ImapServer imapServer;
         private IOptionsMonitor<ServerOptions> serverOptions;
         private IOptionsMonitor<RelayOptions> relayOptions;

--- a/Rnwood.Smtp4dev/Controllers/SessionsController.cs
+++ b/Rnwood.Smtp4dev/Controllers/SessionsController.cs
@@ -20,7 +20,7 @@ namespace Rnwood.Smtp4dev.Controllers
     [UseEtagFilterAttribute]
     public class SessionsController : Controller
     {
-        public SessionsController(Smtp4devDbContext dbContext, Smtp4devServer server)
+        public SessionsController(Smtp4devDbContext dbContext, ISmtp4devServer server)
         {
             this.dbContext = dbContext;
             this.server = server;
@@ -28,7 +28,7 @@ namespace Rnwood.Smtp4dev.Controllers
 
 
         private Smtp4devDbContext dbContext;
-        private Smtp4devServer server;
+        private ISmtp4devServer server;
 
         [HttpGet]
         public IEnumerable<ApiModel.SessionSummary> GetSummaries()

--- a/Rnwood.Smtp4dev/Data/IMessagesRepository.cs
+++ b/Rnwood.Smtp4dev/Data/IMessagesRepository.cs
@@ -1,17 +1,19 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 
 namespace Rnwood.Smtp4dev.Data
 {
-	public interface IMessagesRepository
-	{
-		Task MarkMessageRead(Guid id);
+    public interface IMessagesRepository
+    {
+        Task MarkMessageRead(Guid id);
 
-		IQueryable<DbModel.Message> GetMessages(bool unTracked = true);
+        IQueryable<DbModel.Message> GetMessages(bool unTracked = true);
 
-		Task DeleteMessage(Guid id);
+        Task DeleteMessage(Guid id);
 
-		Task DeleteAllMessages();
-	}
+        Task DeleteAllMessages();
+        Smtp4devDbContext DbContext { get; }
+    }
 }

--- a/Rnwood.Smtp4dev/Data/MessagesRepository.cs
+++ b/Rnwood.Smtp4dev/Data/MessagesRepository.cs
@@ -21,6 +21,8 @@ namespace Rnwood.Smtp4dev.Data
             this.dbContext = dbContext;
         }
 
+        public Smtp4devDbContext DbContext => this.dbContext;
+
         public Task MarkMessageRead(Guid id)
         {
             return taskQueue.QueueTask(() =>

--- a/Rnwood.Smtp4dev/Data/Smtp4devDbContext.cs
+++ b/Rnwood.Smtp4dev/Data/Smtp4devDbContext.cs
@@ -13,9 +13,17 @@ namespace Rnwood.Smtp4dev.Data
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             UtcDateTimeValueConverter.Apply(modelBuilder);
+
+            modelBuilder.Entity<MessageRelay>()
+                .HasOne(r => r.Message)
+                .WithMany(x => x.Relays)
+                .HasForeignKey(x => x.MessageId)
+                .IsRequired();
+
             base.OnModelCreating(modelBuilder);
         }
 
+        public DbSet<MessageRelay> MessageRelays { get; set; }
         public DbSet<Message> Messages { get; set; }
         public DbSet<Session> Sessions { get; set; }
 

--- a/Rnwood.Smtp4dev/DbModel/Message.cs
+++ b/Rnwood.Smtp4dev/DbModel/Message.cs
@@ -1,17 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace Rnwood.Smtp4dev.DbModel
 {
     public class Message
     {
-
-        public Message()
-        {
-        }
-
-        [Key]
-        public Guid Id { get; set; }
+        [Key] public Guid Id { get; set; }
 
         public long ImapUid { get; internal set; }
 
@@ -25,12 +20,21 @@ namespace Rnwood.Smtp4dev.DbModel
 
         public string MimeParseError { get; set; }
 
-        public Session Session { get; set;}
+        public Session Session { get; set; }
         public int AttachmentCount { get; set; }
 
         public bool IsUnread { get; set; }
         public string RelayError { get; internal set; }
-        
+
         public bool SecureConnection { get; set; }
+
+        public virtual List<MessageRelay> Relays { get; set; } = new List<MessageRelay>();
+
+
+        public void AddRelay(MessageRelay messageRelay)
+        {
+            messageRelay.Message = this;
+            this.Relays.Add(messageRelay);
+        }
     }
 }

--- a/Rnwood.Smtp4dev/DbModel/MessageRelay.cs
+++ b/Rnwood.Smtp4dev/DbModel/MessageRelay.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Rnwood.Smtp4dev.DbModel
+{
+    public class MessageRelay
+    {
+        [Key] public Guid Id { get; set; }
+
+        public Guid MessageId { get; set; }
+
+        public virtual Message Message { get; set; }
+
+        public string To { get; set; }
+        public DateTime SendDate { get; set; }
+    }
+}

--- a/Rnwood.Smtp4dev/Migrations/20210807032903_MessageRelay.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210807032903_MessageRelay.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Rnwood.Smtp4dev.Data;
 
 namespace Rnwood.Smtp4dev.Migrations
 {
     [DbContext(typeof(Smtp4devDbContext))]
-    partial class Smtp4devDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210807032903_MessageRelay")]
+    partial class MessageRelay
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Rnwood.Smtp4dev/Migrations/20210807032903_MessageRelay.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210807032903_MessageRelay.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Rnwood.Smtp4dev.Migrations
+{
+    public partial class MessageRelay : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MessageRelays",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    MessageId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    To = table.Column<string>(type: "TEXT", nullable: true),
+                    SendDate = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MessageRelays", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_MessageRelays_Messages_MessageId",
+                        column: x => x.MessageId,
+                        principalTable: "Messages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MessageRelays_MessageId",
+                table: "MessageRelays",
+                column: "MessageId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "MessageRelays");
+        }
+    }
+}

--- a/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
+++ b/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
@@ -28,18 +28,17 @@
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Core" Version="1.1.0" />
 		<PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="5.0.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.8">
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.5" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.8" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.8" />
 		<PackageReference Include="MimeKit" Version="2.13.0" />
 		<PackageReference Include="Mono.Options" Version="6.6.0.161" />
 		<PackageReference Include="Rnwood.LumiSoft.Net" Version="1.0.0" />
 		<PackageReference Include="Rnwood.SmtpServer" Version="3.1.0-ci0648" />
 		<PackageReference Include="Portable.BouncyCastle" Version="1.8.10" />
-		<PackageReference Include="System.Data.SQLite" Version="1.0.114.4" />
 		<PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.12" />
 		<PackageReference Include="System.Reactive" Version="4.4.1" />
 		<PackageReference Include="VueCliMiddleware" Version="3.1.2" />

--- a/Rnwood.Smtp4dev/Server/ISmtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/ISmtp4devServer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using MimeKit;
 using Rnwood.Smtp4dev.DbModel;
 
@@ -11,5 +12,8 @@ namespace Rnwood.Smtp4dev.Server
         bool IsRunning { get; }
         int PortNumber { get; }
         void TryStart();
+        void Stop();
+        Task DeleteSession(Guid id);
+        Task DeleteAllSessions();
     }
 }

--- a/Rnwood.Smtp4dev/Server/ISmtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/ISmtp4devServer.cs
@@ -1,0 +1,15 @@
+using System;
+using MimeKit;
+using Rnwood.Smtp4dev.DbModel;
+
+namespace Rnwood.Smtp4dev.Server
+{
+    public interface ISmtp4devServer
+    {
+        RelayResult TryRelayMessage(Message message, MailboxAddress[] overrideRecipients);
+        Exception Exception { get; }
+        bool IsRunning { get; }
+        int PortNumber { get; }
+        void TryStart();
+    }
+}

--- a/Rnwood.Smtp4dev/Server/RelayOptions.cs
+++ b/Rnwood.Smtp4dev/Server/RelayOptions.cs
@@ -12,7 +12,7 @@ namespace Rnwood.Smtp4dev.Server
 
         public SecureSocketOptions TlsMode { get; set; } = SecureSocketOptions.Auto;
 
-        public string[] AutomaticEmails { get; set; } = new string[0];
+        public string[] AutomaticEmails { get; set; } = System.Array.Empty<string>();
 
         public string SenderAddress { get; set; } = "";
 
@@ -24,14 +24,8 @@ namespace Rnwood.Smtp4dev.Server
         [System.Text.Json.Serialization.JsonIgnore]
         public string AutomaticEmailsString
         {
-            get
-            {
-                return string.Join(",", AutomaticEmails);
-            }
-            set
-            {
-                this.AutomaticEmails = value.Split(',');
-            }
+            get => string.Join(",", AutomaticEmails);
+            set => this.AutomaticEmails = value.Split(',');
         }
     }
 }

--- a/Rnwood.Smtp4dev/Server/RelayResult.cs
+++ b/Rnwood.Smtp4dev/Server/RelayResult.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using MimeKit;
+using Rnwood.Smtp4dev.DbModel;
+
+namespace Rnwood.Smtp4dev.Server
+{
+    public class RelayRecipientResult
+    {
+        public string Email { get; set; }
+        public DateTime RelayDate { get; set; }
+    }
+
+    public class RelayResult
+    {
+        public RelayResult(Message message)
+        {
+            Message = message;
+        }
+
+        public Dictionary<MailboxAddress, Exception> Exceptions { get; set; } = new Dictionary<MailboxAddress, Exception>();
+        public List<RelayRecipientResult> RelayRecipients { get; set; } = new List<RelayRecipientResult>();
+        public bool WasRelayed => RelayRecipients.Count > 0;
+        public Message Message { get; set; }
+    }
+}

--- a/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
@@ -11,13 +11,12 @@ using System.Threading.Tasks;
 using MimeKit;
 using MailKit.Net.Smtp;
 using System.Reactive.Linq;
-using Microsoft.AspNetCore.Mvc.TagHelpers;
 using Microsoft.Extensions.DependencyInjection;
 using Rnwood.Smtp4dev.Data;
 
 namespace Rnwood.Smtp4dev.Server
 {
-    public class Smtp4devServer
+    public class Smtp4devServer : ISmtp4devServer
     {
         public Smtp4devServer(IServiceScopeFactory serviceScopeFactory, IOptionsMonitor<ServerOptions> serverOptions,
             IOptionsMonitor<RelayOptions> relayOptions, NotificationsHub notificationsHub, Func<RelayOptions, SmtpClient> relaySmtpClientFactory, ITaskQueue taskQueue)
@@ -50,8 +49,6 @@ namespace Rnwood.Smtp4dev.Server
             {
                 Console.WriteLine("ServerOptions changed.");
             }
-
-
         }
 
         private void CreateSmtpServer()

--- a/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
@@ -74,7 +74,7 @@ namespace Rnwood.Smtp4dev.Server
             });
         }
 
-        internal void Stop()
+        public void Stop()
         {
             Console.WriteLine("SMTP server stopping...");
             this.smtpServer.Stop(true);
@@ -223,7 +223,7 @@ namespace Rnwood.Smtp4dev.Server
         }
 
 
-        internal Task DeleteSession(Guid id)
+        public Task DeleteSession(Guid id)
         {
             return taskQueue.QueueTask(() =>
             {
@@ -239,7 +239,7 @@ namespace Rnwood.Smtp4dev.Server
             }, true);
         }
 
-        internal Task DeleteAllSessions()
+        public Task DeleteAllSessions()
         {
             return taskQueue.QueueTask(() =>
             {

--- a/Rnwood.Smtp4dev/Startup.cs
+++ b/Rnwood.Smtp4dev/Startup.cs
@@ -57,7 +57,7 @@ namespace Rnwood.Smtp4dev
                 }
             }, ServiceLifetime.Scoped, ServiceLifetime.Singleton);
 
-            services.AddSingleton<Smtp4devServer>();
+            services.AddSingleton<ISmtp4devServer, Smtp4devServer>();
             services.AddSingleton<ImapServer>();
             services.AddScoped<IMessagesRepository, MessagesRepository>();
             services.AddSingleton<ITaskQueue, TaskQueue>();

--- a/Rnwood.Smtp4dev/Startup.cs
+++ b/Rnwood.Smtp4dev/Startup.cs
@@ -140,7 +140,7 @@ namespace Rnwood.Smtp4dev
                     }
                 }
 
-                subdir.ApplicationServices.GetService<Smtp4devServer>().TryStart();
+                subdir.ApplicationServices.GetService<ISmtp4devServer>().TryStart();
                 subdir.ApplicationServices.GetService<ImapServer>().TryStart();
             };
 

--- a/smtp4dev.sln.DotSettings
+++ b/smtp4dev.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rnwood/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Add indicator to UI when a message has been relayed successfully.  (#774)
+ Relay recipients added to table MessageRelay

Other changes:
- swap Smtp4devServer usage with the interface.
- Smtp4devServer -> Stop, DeleteSession, DeleteSessions access modified to public to expose on interface.
- Bump Microsoft.EntityFrameworkCore to 5.0.5 -> 5.0.8 
- Remove legacy System.Data.SQLite lib (ef6?)

![image](https://user-images.githubusercontent.com/127927/128617178-944504a6-0842-45b9-a2fb-25af7261fede.png)
