### PR TITLE
fix (Database): Rebuild Messages table with Primary Key constraint.  …

### DIFF
--- a/Rnwood.Smtp4dev/Migrations/20210901140449_Fix_Messages_PK.Designer.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210901140449_Fix_Messages_PK.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Rnwood.Smtp4dev.Data;
 
 namespace Rnwood.Smtp4dev.Migrations
 {
     [DbContext(typeof(Smtp4devDbContext))]
-    partial class Smtp4devDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210901140449_Fix_Messages_PK")]
+    partial class Fix_Messages_PK
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Rnwood.Smtp4dev/Migrations/20210901140449_Fix_Messages_PK.cs
+++ b/Rnwood.Smtp4dev/Migrations/20210901140449_Fix_Messages_PK.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Rnwood.Smtp4dev.Migrations
+{
+    public partial class Fix_Messages_PK : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+PRAGMA foreign_keys = 0;
+
+create table Messages_dg_tmp
+(
+	Id TEXT not null
+	constraint PK_Messages
+    	primary key,
+	""From"" TEXT,
+    ""To"" TEXT,
+    ReceivedDate TEXT not null,
+    Subject TEXT,
+    Data BLOB,
+    MimeParseError TEXT,
+    SessionId TEXT,
+    AttachmentCount INTEGER default 0 not null,
+    IsUnread INTEGER default 0 not null,
+    RelayError TEXT,
+    ImapUid INTEGER not null,
+    SecureConnection INTEGER default 0 not null
+);
+
+insert into Messages_dg_tmp(Id, ""From"", ""To"", ReceivedDate, Subject, Data, MimeParseError, SessionId, AttachmentCount, IsUnread, RelayError, ImapUid, SecureConnection) 
+    select Id, ""From"", ""To"", ReceivedDate, Subject, Data, MimeParseError, SessionId, AttachmentCount, IsUnread, RelayError, ImapUid, SecureConnection from Messages;
+
+drop table Messages;
+
+alter table Messages_dg_tmp rename to Messages;
+
+create unique index IX_ID
+
+on Messages(Id);
+
+create index IX_Messages_SessionId
+    on Messages(SessionId);
+
+PRAGMA foreign_keys = 1;
+"
+            );
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
This should fix error foreign key mismatch reported in #861

In `Script 20200924120747_AddImapState` , it appears to of not recreated the Primary Key constraint on Messages table.
This SQL migration will recreate the `Messages` table and recreate the primary key constraint.

From the SQLite docs

```
Foreign key DML errors are reported if:

The parent table does not exist, or
The parent key columns named in the foreign key constraint do not exist, or
The parent key columns named in the foreign key constraint are not the primary key of the parent table and are not subject to a unique constraint using collating sequence specified in the CREATE TABLE, or
The child table references the primary key of the parent without specifying the primary key columns and the number of primary key columns in the parent do not match the number of child key columns.
```