### PR TITLE
fix (ImapServer): Check if task is complete before attempting setResult fixes #872

### DIFF
--- a/Rnwood.Smtp4dev/Server/ImapServer.cs
+++ b/Rnwood.Smtp4dev/Server/ImapServer.cs
@@ -75,7 +75,13 @@ namespace Rnwood.Smtp4dev.Server
 
 
             var errorTcs = new TaskCompletionSource<Error_EventArgs>();
-            imapServer.Error += (s, ea) => errorTcs.SetResult(ea);
+            imapServer.Error += (s, ea) =>
+            {
+                if (!errorTcs.Task.IsCompleted)
+                {
+                    errorTcs.SetResult(ea);
+                }
+            };
             var startedTcs = new TaskCompletionSource<EventArgs>();
             imapServer.Started += (s, ea) => startedTcs.SetResult(ea);
 


### PR DESCRIPTION
Fix for Changing settings in UI triggers restart and errors with System.InvalidOperationException in Imapserver.cs when it restarts.  Fixes #872 
