### PR TITLE
feat (CommandLine): Allow option to set baseappdatapath command param  #779

### DIFF
--- a/Rnwood.Smtp4dev.Tests/DirectoryHelperTests.cs
+++ b/Rnwood.Smtp4dev.Tests/DirectoryHelperTests.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.IO;
+using FluentAssertions;
+using Xunit;
+
+namespace Rnwood.Smtp4dev.Tests
+{
+    public class DirectoryHelperTests
+    {
+        private const string OverridePath = "C:\\temp\\";
+        private readonly string appDataPath;
+
+        public DirectoryHelperTests()
+        {
+            appDataPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "smtp4dev");
+        }
+
+        [Fact]
+        public void WhenSpecifiedOnCommandLineOverrideDefault()
+        {
+            var dir = DirectoryHelper.GetDataDir(new CommandLineOptions()
+            {
+                BaseAppData = OverridePath
+            });
+
+            dir.Should().Be(OverridePath);
+        }
+
+        [Fact]
+        public void DefaultDataDirIsAppData()
+        {
+            
+            var dir = DirectoryHelper.GetDataDir(new CommandLineOptions());
+            dir.Should().Be(appDataPath);
+        }
+    }
+}

--- a/Rnwood.Smtp4dev.Tests/DirectoryHelperTests.cs
+++ b/Rnwood.Smtp4dev.Tests/DirectoryHelperTests.cs
@@ -20,7 +20,7 @@ namespace Rnwood.Smtp4dev.Tests
         {
             var dir = DirectoryHelper.GetDataDir(new CommandLineOptions()
             {
-                BaseAppData = OverridePath
+                BaseAppDataPath = OverridePath
             });
 
             dir.Should().Be(OverridePath);

--- a/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
+++ b/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
@@ -26,9 +26,5 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-
   </ItemGroup>
-
-
-
 </Project>

--- a/Rnwood.Smtp4dev/CommandLineOptions.cs
+++ b/Rnwood.Smtp4dev/CommandLineOptions.cs
@@ -11,6 +11,6 @@ namespace Rnwood.Smtp4dev
 
         public bool NoUserSettings { get; set; }
         public bool DebugSettings { get; set; }
-        public string BaseAppData { get; set; }
+        public string BaseAppDataPath { get; set; }
     }
 }

--- a/Rnwood.Smtp4dev/CommandLineOptions.cs
+++ b/Rnwood.Smtp4dev/CommandLineOptions.cs
@@ -1,0 +1,16 @@
+using Rnwood.Smtp4dev.Server;
+
+namespace Rnwood.Smtp4dev
+{
+    public class CommandLineOptions
+    {
+        public ServerOptions ServerOptions { get; set; }
+        public RelayOptions RelayOptions { get; set; }
+
+        public string Urls { get; set; }
+
+        public bool NoUserSettings { get; set; }
+        public bool DebugSettings { get; set; }
+        public string BaseAppData { get; set; }
+    }
+}

--- a/Rnwood.Smtp4dev/CommandLineParser.cs
+++ b/Rnwood.Smtp4dev/CommandLineParser.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommandLiners;
+using Mono.Options;
+
+namespace Rnwood.Smtp4dev
+{
+    public static class CommandLineParser
+    {
+        public static MapOptions<CommandLineOptions> TryParseCommandLine(string[] args)
+        {
+            MapOptions<CommandLineOptions> map = new MapOptions<CommandLineOptions>();
+
+            bool help = false;
+
+            OptionSet options = new OptionSet
+            {
+                { "h|help|?", "Shows this message and exits", _ =>  help = true},
+                { "service", "Required to run when registered as a Windows service. To register service: sc.exe create Smtp4dev binPath= \"{PathToExe} --service\"", _ => { } },
+                { "urls=", "The URLs the web interface should listen on. For example, http://localhost:123. Use `*` in place of hostname to listen for requests on any IP address or hostname using the specified port and protocol (for example, http://*:5000)", data => map.Add(data, x => x.Urls) },
+                { "hostname=", "Specifies the server hostname. Used in auto-generated TLS certificate if enabled.", data => map.Add(data, x => x.ServerOptions.HostName) },
+                { "baseappdata=","Set the base config and appData path", data=> map.Add(data,x=>x.BaseAppData)},
+                { "allowremoteconnections", "Specifies if remote connections will be allowed to the SMTP and IMAP servers. Use -allowremoteconnections+ to enable or -allowremoteconnections- to disable", data => map.Add((data !=null).ToString(), x => x.ServerOptions.AllowRemoteConnections) },
+                { "smtpport=", "Set the port the SMTP server listens on. Specify 0 to assign automatically", data => map.Add(data, x => x.ServerOptions.Port) },
+                { "db=", "Specifies the path where the database will be stored relative to APPDATA env var on Windows or XDG_CONFIG_HOME on non-Windows. Specify \"\" to use an in memory database.", data => map.Add(data, x => x.ServerOptions.Database) },
+                { "messagestokeep=", "Specifies the number of messages to keep", data => map.Add(data, x=> x.ServerOptions.NumberOfMessagesToKeep) },
+                { "sessionstokeep=", "Specifies the number of sessions to keep", data => map.Add(data, x=> x.ServerOptions.NumberOfSessionsToKeep) },
+                { "tlsmode=", "Specifies the TLS mode to use. None=Off. StartTls=On demand if client supports STARTTLS. ImplicitTls=TLS as soon as connection is established.", data => map.Add(data, x=> x.ServerOptions.TlsMode) },
+                { "tlscertificate=", "Specifies the TLS certificate to use if TLS is enabled/requested. Specify \"\" to use an auto-generated self-signed certificate (then see console output on first startup)", data => map.Add(data, x=> x.ServerOptions.TlsCertificate) },
+                { "basepath=", "Specifies the virtual path from web server root where SMTP4DEV web interface will be hosted. e.g. \"/\" or \"/smtp4dev\"", data => map.Add(data, x => x.ServerOptions.BasePath) },
+                { "relaysmtpserver=", "Sets the name of the SMTP server that will be used to relay messages or \"\" if messages relay should not be allowed", data => map.Add(data, x=> x.RelayOptions.SmtpServer) },
+                { "relaysmtpport=", "Sets the port number for the SMTP server used to relay messages", data => map.Add(data, x=> x.RelayOptions.SmtpServer) },
+                { "relayautomaticallyemails=", "A comma separated list of recipient addresses for which messages will be relayed automatically. An empty list means that no messages are relayed", data => map.Add(data, x=> x.RelayOptions.AutomaticEmailsString) },
+                { "relaysenderaddress=", "Specifies the address used in MAIL FROM when relaying messages. (Sender address in message headers is left unmodified). The sender of each message is used if not specified.", data => map.Add(data, x=> x.RelayOptions.SenderAddress) },
+                { "relayusername=", "The username for the SMTP server used to relay messages. If \"\" no authentication is attempted", data => map.Add(data, x=> x.RelayOptions.Login) },
+                { "relaypassword=", "The password for the SMTP server used to relay messages", data => map.Add(data, x=> x.RelayOptions.Password) },
+                { "relaytlsmode=",  "Sets the TLS mode when connecting to relay SMTP server. See: http://www.mimekit.net/docs/html/T_MailKit_Security_SecureSocketOptions.htm", data => map.Add(data, x=> x.RelayOptions.TlsMode) },
+                { "imapport=", "Specifies the port the IMAP server will listen on - allows standard email clients to view/retrieve messages", data => map.Add(data, x=> x.ServerOptions.ImapPort) },
+                { "nousersettings", "Skip loading of appsetttings.json file in %APPDATA%", data => map.Add((data !=null).ToString(), x=> x.NoUserSettings) },
+                { "debugsettings", "Prints out most settings values on startup", data => map.Add((data !=null).ToString(), x=> x.DebugSettings) },
+                { "recreatedb", "Recreates the DB on startup if it already exists", data => map.Add((data !=null).ToString(), x=> x.ServerOptions.RecreateDb) }
+            };
+
+            try
+            {
+                List<string> badArgs = options.Parse(args);
+                if (badArgs.Any())
+                {
+                    Console.Error.WriteLine("Unrecognised command line arguments: " + string.Join(" ", badArgs));
+                    help = true;
+                }
+
+            }
+            catch (OptionException e)
+            {
+                Console.Error.WriteLine("Invalid command line: " + e.Message);
+                help = true;
+            }
+
+            if (help)
+            {
+                Console.Error.WriteLine();
+                Console.Error.WriteLine(" > For information about default values see documentation in appsettings.json.");
+                Console.Error.WriteLine();
+                options.WriteOptionDescriptions(Console.Error);
+                return null;
+            }
+            else
+            {
+                Console.WriteLine();
+                Console.WriteLine(" > For help use argument --help");
+                Console.WriteLine();
+            }
+
+            return map;
+        }
+    }
+}

--- a/Rnwood.Smtp4dev/CommandLineParser.cs
+++ b/Rnwood.Smtp4dev/CommandLineParser.cs
@@ -20,7 +20,7 @@ namespace Rnwood.Smtp4dev
                 { "service", "Required to run when registered as a Windows service. To register service: sc.exe create Smtp4dev binPath= \"{PathToExe} --service\"", _ => { } },
                 { "urls=", "The URLs the web interface should listen on. For example, http://localhost:123. Use `*` in place of hostname to listen for requests on any IP address or hostname using the specified port and protocol (for example, http://*:5000)", data => map.Add(data, x => x.Urls) },
                 { "hostname=", "Specifies the server hostname. Used in auto-generated TLS certificate if enabled.", data => map.Add(data, x => x.ServerOptions.HostName) },
-                { "baseappdata=","Set the base config and appData path", data=> map.Add(data,x=>x.BaseAppData)},
+                { "baseappdatapath=","Set the base config and appData path", data=> map.Add(data,x=>x.BaseAppDataPath)},
                 { "allowremoteconnections", "Specifies if remote connections will be allowed to the SMTP and IMAP servers. Use -allowremoteconnections+ to enable or -allowremoteconnections- to disable", data => map.Add((data !=null).ToString(), x => x.ServerOptions.AllowRemoteConnections) },
                 { "smtpport=", "Set the port the SMTP server listens on. Specify 0 to assign automatically", data => map.Add(data, x => x.ServerOptions.Port) },
                 { "db=", "Specifies the path where the database will be stored relative to APPDATA env var on Windows or XDG_CONFIG_HOME on non-Windows. Specify \"\" to use an in memory database.", data => map.Add(data, x => x.ServerOptions.Database) },

--- a/Rnwood.Smtp4dev/DirectoryHelper.cs
+++ b/Rnwood.Smtp4dev/DirectoryHelper.cs
@@ -7,9 +7,9 @@ namespace Rnwood.Smtp4dev
     {
         public static string GetDataDir(CommandLineOptions options)
         {
-            return string.IsNullOrEmpty(options.BaseAppData)
+            return string.IsNullOrEmpty(options.BaseAppDataPath)
                 ? Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "smtp4dev")
-                : options.BaseAppData;
+                : options.BaseAppDataPath;
         }
     }
 }

--- a/Rnwood.Smtp4dev/DirectoryHelper.cs
+++ b/Rnwood.Smtp4dev/DirectoryHelper.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.IO;
+
+namespace Rnwood.Smtp4dev
+{
+    public static class DirectoryHelper
+    {
+        public static string GetDataDir(CommandLineOptions options)
+        {
+            return string.IsNullOrEmpty(options.BaseAppData)
+                ? Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "smtp4dev")
+                : options.BaseAppData;
+        }
+    }
+}

--- a/Rnwood.Smtp4dev/Program.cs
+++ b/Rnwood.Smtp4dev/Program.cs
@@ -81,8 +81,7 @@ namespace Rnwood.Smtp4dev
 
         private static IWebHost BuildWebHost(string[] args)
         {
-
-            MapOptions<CommandLineOptions> commandLineOptions = TryParseCommandLine(args);
+            MapOptions<CommandLineOptions> commandLineOptions = CommandLineParser.TryParseCommandLine(args);
             if (commandLineOptions == null)
             {
                 Environment.Exit(1);
@@ -148,73 +147,6 @@ namespace Rnwood.Smtp4dev
             return builder.Build();
         }
 
-
-        private static MapOptions<CommandLineOptions> TryParseCommandLine(string[] args)
-        {
-            MapOptions<CommandLineOptions> map = new MapOptions<CommandLineOptions>();
-
-            bool help = false;
-
-            OptionSet options = new OptionSet
-            {
-                { "h|help|?", "Shows this message and exits", _ =>  help = true},
-                { "service", "Required to run when registered as a Windows service. To register service: sc.exe create Smtp4dev binPath= \"{PathToExe} --service\"", _ => { } },
-                { "urls=", "The URLs the web interface should listen on. For example, http://localhost:123. Use `*` in place of hostname to listen for requests on any IP address or hostname using the specified port and protocol (for example, http://*:5000)", data => map.Add(data, x => x.Urls) },
-                { "hostname=", "Specifies the server hostname. Used in auto-generated TLS certificate if enabled.", data => map.Add(data, x => x.ServerOptions.HostName) },
-                { "allowremoteconnections", "Specifies if remote connections will be allowed to the SMTP and IMAP servers. Use -allowremoteconnections+ to enable or -allowremoteconnections- to disable", data => map.Add((data !=null).ToString(), x => x.ServerOptions.AllowRemoteConnections) },
-                { "smtpport=", "Set the port the SMTP server listens on. Specify 0 to assign automatically", data => map.Add(data, x => x.ServerOptions.Port) },
-                { "db=", "Specifies the path where the database will be stored relative to APPDATA env var on Windows or XDG_CONFIG_HOME on non-Windows. Specify \"\" to use an in memory database.", data => map.Add(data, x => x.ServerOptions.Database) },
-                { "messagestokeep=", "Specifies the number of messages to keep", data => map.Add(data, x=> x.ServerOptions.NumberOfMessagesToKeep) },
-                { "sessionstokeep=", "Specifies the number of sessions to keep", data => map.Add(data, x=> x.ServerOptions.NumberOfSessionsToKeep) },
-                { "tlsmode=", "Specifies the TLS mode to use. None=Off. StartTls=On demand if client supports STARTTLS. ImplicitTls=TLS as soon as connection is established.", data => map.Add(data, x=> x.ServerOptions.TlsMode) },
-                { "tlscertificate=", "Specifies the TLS certificate to use if TLS is enabled/requested. Specify \"\" to use an auto-generated self-signed certificate (then see console output on first startup)", data => map.Add(data, x=> x.ServerOptions.TlsCertificate) },
-                { "basepath=", "Specifies the virtual path from web server root where SMTP4DEV web interface will be hosted. e.g. \"/\" or \"/smtp4dev\"", data => map.Add(data, x => x.ServerOptions.BasePath) },
-                { "relaysmtpserver=", "Sets the name of the SMTP server that will be used to relay messages or \"\" if messages relay should not be allowed", data => map.Add(data, x=> x.RelayOptions.SmtpServer) },
-                { "relaysmtpport=", "Sets the port number for the SMTP server used to relay messages", data => map.Add(data, x=> x.RelayOptions.SmtpServer) },
-                { "relayautomaticallyemails=", "A comma separated list of recipient addresses for which messages will be relayed automatically. An empty list means that no messages are relayed", data => map.Add(data, x=> x.RelayOptions.AutomaticEmailsString) },
-                { "relaysenderaddress=", "Specifies the address used in MAIL FROM when relaying messages. (Sender address in message headers is left unmodified). The sender of each message is used if not specified.", data => map.Add(data, x=> x.RelayOptions.SenderAddress) },
-                { "relayusername=", "The username for the SMTP server used to relay messages. If \"\" no authentication is attempted", data => map.Add(data, x=> x.RelayOptions.Login) },
-                { "relaypassword=", "The password for the SMTP server used to relay messages", data => map.Add(data, x=> x.RelayOptions.Password) },
-                { "relaytlsmode=",  "Sets the TLS mode when connecting to relay SMTP server. See: http://www.mimekit.net/docs/html/T_MailKit_Security_SecureSocketOptions.htm", data => map.Add(data, x=> x.RelayOptions.TlsMode) },
-                { "imapport=", "Specifies the port the IMAP server will listen on - allows standard email clients to view/retrieve messages", data => map.Add(data, x=> x.ServerOptions.ImapPort) },
-                { "nousersettings", "Skip loading of appsetttings.json file in %APPDATA%", data => map.Add((data !=null).ToString(), x=> x.NoUserSettings) },
-                { "debugsettings", "Prints out most settings values on startup", data => map.Add((data !=null).ToString(), x=> x.DebugSettings) },
-                { "recreatedb", "Recreates the DB on startup if it already exists", data => map.Add((data !=null).ToString(), x=> x.ServerOptions.RecreateDb) }
-            };
-
-            try
-            {
-                List<string> badArgs = options.Parse(args);
-                if (badArgs.Any())
-                {
-                    Console.Error.WriteLine("Unrecognised command line arguments: " + string.Join(" ", badArgs));
-                    help = true;
-                }
-
-            }
-            catch (OptionException e)
-            {
-                Console.Error.WriteLine("Invalid command line: " + e.Message);
-                help = true;
-            }
-
-            if (help)
-            {
-                Console.Error.WriteLine();
-                Console.Error.WriteLine(" > For information about default values see documentation in appsettings.json.");
-                Console.Error.WriteLine();
-                options.WriteOptionDescriptions(Console.Error);
-                return null;
-            }
-            else
-            {
-                Console.WriteLine();
-                Console.WriteLine(" > For help use argument --help");
-                Console.WriteLine();
-            }
-
-            return map;
-        }
 
         private static string GetOrCreateDataDir(CommandLineOptions cmdLineOptions)
         {

--- a/Rnwood.Smtp4dev/Server/ServerOptions.cs
+++ b/Rnwood.Smtp4dev/Server/ServerOptions.cs
@@ -1,10 +1,4 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Net;
-using System.Threading.Tasks;
+﻿using System.Net;
 
 namespace Rnwood.Smtp4dev.Server
 {

--- a/Rnwood.Smtp4dev/Startup.cs
+++ b/Rnwood.Smtp4dev/Startup.cs
@@ -127,9 +127,6 @@ namespace Rnwood.Smtp4dev
                     }
                 });
 
-
-
-
                 using (IServiceScope scope = subdir.ApplicationServices.CreateScope())
                 {
                     using (Smtp4devDbContext context = scope.ServiceProvider.GetService<Smtp4devDbContext>())

--- a/Rnwood.Smtp4dev/appsettings.json
+++ b/Rnwood.Smtp4dev/appsettings.json
@@ -5,7 +5,7 @@
   //
   //Values specified here can be overriden in the following places (in order of processing - last wins)
   // - ~/appsettings.{Environment}.json - Where {Environment} is from ASPNETCORE_ENVIRONMENT env var
-  // - {AppData}/smtp4dev/appsettings.json - Where {AppData} is APPDATA env var on Windows or XDG_CONFIG_HOME on non-Windows
+  // - {AppData}/smtp4dev/appsettings.json - Where {AppData} is value of --baseappdatapath command line option (default: APPDATA env var on Windows or XDG_CONFIG_HOME on non-Windows)
   // - Environmment variables in format "ServerOptions:HostName" (Windows) or "ServerOptions__HostName" (Other platforms)
   // - Command line arguments - Specify --help for documentation.
 

--- a/smtp4dev.sln.DotSettings
+++ b/smtp4dev.sln.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rnwood/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Rnwood/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unrecognised/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Allow setting a path to base configs from. Resolves #779

New command line parameter `--baseappdatapath `- Set the base app data folder, which will be use to read config and set relative path for config such as db location.
**NOTE**: `--basepath` is already used to set virtual path for webroot., so it was not selected for the param name

**Additional changes**
- Removed code in startup that was migrating the db to new location.  Since dbname can be configured this code is possibly confusing and superceded.
- refactor config into separate class

**Example usage**

```
rnwood.smtp4dev --baseappdatapath=C:\data\
```

This will read from any `appsetting.json` located in the `baseAppDataPath` (along with the existing approach of first reading config in the binaries folder, and use this as the base path for the db location.

This change assists in maintaining configuration in a folder that may be specific to custom installations.  It also helps provide isolation in the event you want to run more than one instance of the app on the same pc.