### PR TITLE
Fix (SSCertGenerator\Warnings): Fix warnings from using obsolete method

### DIFF
--- a/Rnwood.Smtp4dev.Tests/Server/SSCertGenerator/CertificateTests.cs
+++ b/Rnwood.Smtp4dev.Tests/Server/SSCertGenerator/CertificateTests.cs
@@ -1,0 +1,15 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace Rnwood.Smtp4dev.Tests.Server.SSCertGenerator
+{
+    public class CertificateTests
+    {
+        [Fact]
+        public void CanGenerateSelfSignedCertificate()
+        {
+            var cert = Smtp4dev.Server.SSCertGenerator.CreateSelfSignedCertificate("localhost");
+            cert.Should().NotBeNull();
+        }
+    }
+}


### PR DESCRIPTION
Replace obsolete method calls with recommended approach of using `SignatureFactory` to remove compile warnings

Warnings were:

```
Rnwood.Smtp4dev\Server\SSCertGenerator.cs(33,13): Warning CS0618: 'X509V3CertificateGenerator.SetSignatureAlgorithm(string)' is obsolete: 'Not needed if Generate used with an ISignatureFactory'

Rnwood.Smtp4dev\Server\SSCertGenerator.cs(45,24): Warning CS0618: 'X509V3CertificateGenerator.Generate(AsymmetricKeyParameter, SecureRandom)' is obsolete: 'Use Generate with an ISignatureFactory'
```
