### PR TITLE
fix (CommandLine): RelaySmtpPort now gets set correctly from commandline

### DIFF
--- a/Rnwood.Smtp4dev.Tests/CommandLine/ParseCommandLineTests.cs
+++ b/Rnwood.Smtp4dev.Tests/CommandLine/ParseCommandLineTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+using CommandLiners;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Rnwood.Smtp4dev.Tests.CommandLine
+{
+    public class ParseCommandLineTests
+    {
+        private const string RelaySmtpPortParam = "--relaysmtpport";
+
+        [Theory]
+        [InlineData(500)]
+        public void CanParseRelaySmtpPort(int portNumber)
+        {
+            var commandLineOptions = CommandLineParser.TryParseCommandLine(new[] { $"{RelaySmtpPortParam}={portNumber}" });
+            var cmdLineOptions = new CommandLineOptions();
+            new ConfigurationBuilder().AddCommandLineOptions(commandLineOptions).Build().Bind(cmdLineOptions);
+            cmdLineOptions.RelayOptions.SmtpPort.Should().Be(portNumber);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(67000)]
+        public void SmtpPortMustBeValidTcpPort(int portNumber)
+        {
+            // TCP port range 1-65535 is valid
+            var commandLineOptions = CommandLineParser.TryParseCommandLine(new[] { $"{RelaySmtpPortParam}={portNumber}" });
+            var cmdLineOptions = new CommandLineOptions();
+            Action act = () => new ConfigurationBuilder().AddCommandLineOptions(commandLineOptions).Build().Bind(cmdLineOptions);
+            act.Should().Throw<TargetInvocationException>().WithInnerException<ArgumentOutOfRangeException>();
+        }
+    }
+}

--- a/Rnwood.Smtp4dev/CommandLineParser.cs
+++ b/Rnwood.Smtp4dev/CommandLineParser.cs
@@ -30,7 +30,7 @@ namespace Rnwood.Smtp4dev
                 { "tlscertificate=", "Specifies the TLS certificate to use if TLS is enabled/requested. Specify \"\" to use an auto-generated self-signed certificate (then see console output on first startup)", data => map.Add(data, x=> x.ServerOptions.TlsCertificate) },
                 { "basepath=", "Specifies the virtual path from web server root where SMTP4DEV web interface will be hosted. e.g. \"/\" or \"/smtp4dev\"", data => map.Add(data, x => x.ServerOptions.BasePath) },
                 { "relaysmtpserver=", "Sets the name of the SMTP server that will be used to relay messages or \"\" if messages relay should not be allowed", data => map.Add(data, x=> x.RelayOptions.SmtpServer) },
-                { "relaysmtpport=", "Sets the port number for the SMTP server used to relay messages", data => map.Add(data, x=> x.RelayOptions.SmtpServer) },
+                { "relaysmtpport=", "Sets the port number for the SMTP server used to relay messages", data => map.Add(data, x=> x.RelayOptions.SmtpPort) },
                 { "relayautomaticallyemails=", "A comma separated list of recipient addresses for which messages will be relayed automatically. An empty list means that no messages are relayed", data => map.Add(data, x=> x.RelayOptions.AutomaticEmailsString) },
                 { "relaysenderaddress=", "Specifies the address used in MAIL FROM when relaying messages. (Sender address in message headers is left unmodified). The sender of each message is used if not specified.", data => map.Add(data, x=> x.RelayOptions.SenderAddress) },
                 { "relayusername=", "The username for the SMTP server used to relay messages. If \"\" no authentication is attempted", data => map.Add(data, x=> x.RelayOptions.Login) },

--- a/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
+++ b/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
@@ -20,6 +20,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Ardalis.GuardClauses" Version="3.2.0" />
 		<PackageReference Include="CommandLiners.MonoOptions" Version="1.0.36" />
 		<PackageReference Include="HtmlAgilityPack" Version="1.11.36" />
 		<PackageReference Include="MailKit" Version="2.13.0" />

--- a/Rnwood.Smtp4dev/Server/RelayOptions.cs
+++ b/Rnwood.Smtp4dev/Server/RelayOptions.cs
@@ -1,14 +1,24 @@
-﻿using MailKit.Security;
+﻿using Ardalis.GuardClauses;
+using MailKit.Security;
 
 namespace Rnwood.Smtp4dev.Server
 {
     public class RelayOptions
     {
+        private int smtpPort = 25;
         public bool IsEnabled => SmtpServer != string.Empty;
 
         public string SmtpServer { get; set; } = string.Empty;
 
-        public int SmtpPort { get; set; } = 25;
+        public int SmtpPort
+        {
+            get => smtpPort;
+            set
+            {
+                Guard.Against.OutOfRange(value, nameof(SmtpPort), 1, 65535);
+                smtpPort = value;
+            }
+        }
 
         public SecureSocketOptions TlsMode { get; set; } = SecureSocketOptions.Auto;
 


### PR DESCRIPTION
RelaySmtpPort was setting the wrong value when set from the commandline.
* Added guard on SmtpPort number value.
Fixes #871