### PR TITLE
fix (IIS): Adjust path to save settings to when hosted in IIS

### DIFF
--- a/Rnwood.Smtp4dev/Program.cs
+++ b/Rnwood.Smtp4dev/Program.cs
@@ -93,7 +93,7 @@ namespace Rnwood.Smtp4dev
 
             var contentRoot = GetContentRoot();
             var dataDir = GetOrCreateDataDir(cmdLineOptions);
-            Console.WriteLine($"DataDir: {dataDir}");
+            log.Information("DataDir: {dataDir}", dataDir);
             Directory.SetCurrentDirectory(dataDir);
 
             IWebHostBuilder builder = WebHost

--- a/Rnwood.Smtp4dev/Service/HostingEnvironmentHelper.cs
+++ b/Rnwood.Smtp4dev/Service/HostingEnvironmentHelper.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Hosting;
+
+namespace Rnwood.Smtp4dev.Service
+{
+    public interface IHostingEnvironmentHelper
+    {
+        string GetSettingsFilePath();
+    }
+
+    public class HostingEnvironmentHelper : IHostingEnvironmentHelper
+    {
+        private readonly IHostEnvironment hostEnvironment;
+
+        public HostingEnvironmentHelper(IHostEnvironment hostEnvironment)
+        {
+            this.hostEnvironment = hostEnvironment;
+        }
+
+        /// <summary>
+        /// Check if this process is running on Windows in an in process instance in IIS
+        /// </summary>
+        /// <returns>True if Windows and in an in process instance on IIS, false otherwise</returns>
+        private static bool IsRunningInProcessIIS()
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return false;
+            }
+
+            var processName = Path.GetFileNameWithoutExtension(Process.GetCurrentProcess().ProcessName);
+            return (processName.Contains("w3wp", StringComparison.OrdinalIgnoreCase) ||
+                    processName.Contains("iisexpress", StringComparison.OrdinalIgnoreCase));
+        }
+
+        /// <summary>
+        /// Get path to appsettings.json, for IIS this is the runtime path.
+        /// </summary>
+        /// <returns>appsettings.json filePath</returns>
+        public string GetSettingsFilePath()
+        {
+            var dataDir = IsRunningInProcessIIS()
+                ? Path.Join(hostEnvironment.ContentRootPath, "smtp4dev")
+                : Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "smtp4dev");
+            return Path.Join(dataDir, "appsettings.json");
+        }
+    }
+}


### PR DESCRIPTION
In IIS, the path scanned for config was `<iis_install_dir>/smtp4dev/smtp4dev/appsettings.json`
This changes reduces the path under IIS to `<iis_install_dir>/smtp4dev/appsettings.json`.  This is a shipped path and avoids an issue encountered in #898
Resolves #898 

Please consider merging #876 as well, as a restart of the server (via saving config) is throwing an error,  I believe should be fixed by that PR.