### PR TITLE
feat (Version): Add version API and to UI

### DIFF
--- a/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
+++ b/Rnwood.Smtp4dev.Tests/Rnwood.Smtp4dev.Tests.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
-    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="92.0.4515.10700" />
+    <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="94.0.4606.6100" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
     <PackageReference Include="System.Linq.Dynamic.Core" Version="1.2.13" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Rnwood.Smtp4dev/ApiModel/Info.cs
+++ b/Rnwood.Smtp4dev/ApiModel/Info.cs
@@ -1,0 +1,8 @@
+﻿namespace Rnwood.Smtp4dev.ApiModel
+{
+    public class Info
+    {
+        public string Version { get; set; }
+        public string InfoVersion { get; set; }
+    }
+}

--- a/Rnwood.Smtp4dev/ClientApp/src/ApiClient/Info.ts
+++ b/Rnwood.Smtp4dev/ClientApp/src/ApiClient/Info.ts
@@ -1,0 +1,11 @@
+﻿export default class Info {
+ 
+    constructor(version: string, infoVersion: string) {
+         
+        this.version = version;
+        this.infoVersion = infoVersion;
+    }
+
+    version: string;
+    infoVersion: string;
+}

--- a/Rnwood.Smtp4dev/ClientApp/src/ApiClient/InfoController.ts
+++ b/Rnwood.Smtp4dev/ClientApp/src/ApiClient/InfoController.ts
@@ -1,0 +1,15 @@
+﻿import axios from "axios";
+import Info from "./Info";
+
+export default class InfoController {
+    constructor() {}
+
+    public getInfo_url(): string {
+        return `api/Info`;
+    }
+
+    public async getInfo(): Promise<Info> {
+        return (await axios.get(this.getInfo_url(), null || undefined))
+            .data as Info;
+    }
+}

--- a/Rnwood.Smtp4dev/ClientApp/src/components/home/home.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/home/home.vue
@@ -6,6 +6,9 @@
                     <img height="35" src="logo.png" alt="smtp4dev" />
                 </a>
             </h1>
+            <div style="padding-left:10px; padding-top:5px; margin-left:10px; width:30em;display:inline-block">
+                <VersionInfo></VersionInfo>
+            </div>
             <el-button style="float:right; font-size: 1.7em; padding: 6px; margin: 0 3px" circle icon="el-icon-setting" title="Settings" @click="settingsVisible = true"></el-button>&nbsp;
             <hubconnstatus style="float:right" :connection="connection"></hubconnstatus>
             <serverstatus style="float:right" v-show="connection && connection.connected" :connection="connection"></serverstatus>
@@ -60,6 +63,7 @@
     import MessageView from "@/components/messageview.vue";
     import SessionList from "@/components/sessionlist.vue";
     import SessionView from "@/components/sessionview.vue";
+    import VersionInfo from "@/components/versionInfo.vue";
     import HubConnectionManager from "@/HubConnectionManager";
     import ServerStatus from "@/components/serverstatus.vue";
     import SettingsDialog from "@/components/settingsdialog.vue";
@@ -77,7 +81,8 @@
             serverstatus: ServerStatus,
             settingsdialog: SettingsDialog,
             splitpanes: Splitpanes,
-            pane: Pane
+            pane: Pane,
+            VersionInfo
         }
     })
     export default class Home extends Vue {

--- a/Rnwood.Smtp4dev/ClientApp/src/components/versionInfo.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/versionInfo.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>Version: <span v-text="version"></span></div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import Component from "vue-class-component";
+import Info from "../ApiClient/Info";
+import InfoController from "../ApiClient/InfoController";
+
+@Component({})
+export default class Version extends Vue {
+  info: Info | null = null;
+
+  async mounted() {
+    this.info = await new InfoController().getInfo();
+  }
+
+  get version() {
+    return this.info?.infoVersion ?? "";
+  }
+}
+</script>

--- a/Rnwood.Smtp4dev/ClientApp/vue.config.js
+++ b/Rnwood.Smtp4dev/ClientApp/vue.config.js
@@ -1,4 +1,16 @@
 module.exports = {
+    devServer: {
+        proxy: {
+            '^/api' : {
+                target: 'http://localhost:5000',
+                changeOrigin:true
+            },
+            '^/hubs': {
+                target: 'http://localhost:5000',
+                changeOrigin:true
+            }
+        }
+    },
     outputDir: '../wwwroot',
     publicPath: './',
     configureWebpack: {

--- a/Rnwood.Smtp4dev/Controllers/InfoController.cs
+++ b/Rnwood.Smtp4dev/Controllers/InfoController.cs
@@ -1,0 +1,20 @@
+﻿using System.Reflection;
+using Microsoft.AspNetCore.Mvc;
+using Rnwood.Smtp4dev.ApiModel;
+
+namespace Rnwood.Smtp4dev.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    [UseEtagFilter]
+    public class InfoController : Controller
+    {
+        [HttpGet]
+        public ActionResult<Info> Get()
+        {
+            var version = Assembly.GetExecutingAssembly().GetName().Version?.ToString();
+            var infoVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+            return new Info { Version = version, InfoVersion = infoVersion };
+        }
+    }
+}

--- a/Rnwood.Smtp4dev/Program.cs
+++ b/Rnwood.Smtp4dev/Program.cs
@@ -34,7 +34,7 @@ namespace Rnwood.Smtp4dev
                 string version = FileVersionInfo.GetVersionInfo(typeof(Program).Assembly.Location).ProductVersion;
                 log.Information("smtp4dev version {version}",version);
                 log.Information("https://github.com/rnwood/smtp4dev");
-                log.Information(".NET Core runtime version: {netcoreruntime}",Directory.GetParent(typeof(object).Assembly.Location).Name);
+                log.Information(".NET Core runtime version: {netcoreruntime}", System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription);
 
 
                 if (!Debugger.IsAttached && args.Contains("--service"))

--- a/Rnwood.Smtp4dev/Startup.cs
+++ b/Rnwood.Smtp4dev/Startup.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.SpaServices;
 using MailKit.Net.Smtp;
 using Microsoft.AspNetCore.Rewrite;
 using Rnwood.Smtp4dev.Data;
+using Rnwood.Smtp4dev.Service;
 using Serilog;
 
 namespace Rnwood.Smtp4dev
@@ -61,6 +62,7 @@ namespace Rnwood.Smtp4dev
             services.AddSingleton<ISmtp4devServer, Smtp4devServer>();
             services.AddSingleton<ImapServer>();
             services.AddScoped<IMessagesRepository, MessagesRepository>();
+            services.AddScoped<IHostingEnvironmentHelper, HostingEnvironmentHelper>();
             services.AddSingleton<ITaskQueue, TaskQueue>();
 
             services.AddSingleton<Func<RelayOptions, SmtpClient>>((relayOptions) =>


### PR DESCRIPTION
# Feature
Adds the app Version to the header UI
Exposes endpoint  GET /api/info with payload:

Example payload: 

```json
{
"version" : "3.1.0",
"infoVersion": "3.1.0-Dev"
}
```

![image](https://user-images.githubusercontent.com/127927/137568200-d1b6a350-bd4b-48ac-a8a1-9c0582f44b9a.png)

Resolves: #928 
includes: CherryPicked: #914 