### PR TITLE
Docker image update

### DIFF
--- a/Dockerfile.linux
+++ b/Dockerfile.linux
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.5 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
 COPY out /app
 VOLUME ["/smtp4dev"]
 WORKDIR /

--- a/Dockerfile.linux.arm64
+++ b/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:6.0.5 AS runtime
+FROM --platform=linux/arm64 mcr.microsoft.com/dotnet/aspnet:7.0 AS runtime
 COPY out /app
 VOLUME ["/smtp4dev"]
 WORKDIR /

--- a/Dockerfile.windows
+++ b/Dockerfile.windows
@@ -1,5 +1,5 @@
 # escape=`
-FROM mcr.microsoft.com/dotnet/aspnet:6.0.5 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:7.0 AS final
 COPY out /app
 EXPOSE 80
 EXPOSE 25


### PR DESCRIPTION
Please, publish updated Docker images. https://hub.docker.com/r/rnwood/smtp4dev:v3 is based on .NET 3 that does not support Apple M1 processor