### PR TITLE
Feat(SMTP): Delay expressions for messages and recipients to extend testing capabilities

### DIFF
--- a/Rnwood.Smtp4dev/ApiModel/Server.cs
+++ b/Rnwood.Smtp4dev/ApiModel/Server.cs
@@ -34,7 +34,9 @@ namespace Rnwood.Smtp4dev.ApiModel
         public string CredentialsValidationExpression { get; set; }
         public bool SecureConnectionRequired { get; set; }
         public string RecipientValidationExpression { get; set; }
+        public string RecipientDelayExpression { get; set; }
         public string MessageValidationExpression { get; set; }
+        public string MessageDelayExpression { get; set; }
 		public bool DisableIPv6 { get; set; }
         public UserOptions[] Users { get; set; }
 

--- a/Rnwood.Smtp4dev/ClientApp/src/ApiClient/Server.ts
+++ b/Rnwood.Smtp4dev/ClientApp/src/ApiClient/Server.ts
@@ -8,7 +8,12 @@ export default class Server {
 
     constructor(isRunning: boolean, exception: string, portNumber: number, hostName: string, allowRemoteConnections: boolean, numberOfMessagesToKeep: number, numberOfSessionsToKeep: number, imapPortNumber: number, settingsAreEditable: boolean, disableMessageSanitisation: boolean, automaticRelayExpression: string, tlsMode: string, credentialsValidationExpression: string,
         authenticationRequired: boolean,
-        secureConnectionRequired: boolean, recipientValidationExpression: string, messageValidationExpression: string, disableIPv6: string, users: User[],
+        secureConnectionRequired: boolean, 
+        recipientValidationExpression: string, 
+        recipientDelayExpression: string, 
+        messageValidationExpression: string, 
+        messageDelayExpression: string, 
+        disableIPv6: string, users: User[],
         relayTlsMode: string | undefined,
         relaySmtpServer: string,
         relaySmtpPort: number,
@@ -44,7 +49,9 @@ export default class Server {
         this.authenticationRequired = authenticationRequired;
         this.secureConnectionRequired = secureConnectionRequired;
         this.recipientValidationExpression = recipientValidationExpression;
+        this.recipientDelayExpression = recipientDelayExpression;
         this.messageValidationExpression = messageValidationExpression;
+        this.messageDelayExpression = messageDelayExpression;
         this.disableIPv6 = disableIPv6;
         this.users = users;
         this.relayTlsMode = relayTlsMode;
@@ -83,7 +90,9 @@ export default class Server {
     authenticationRequired: boolean;
     secureConnectionRequired: boolean;
     recipientValidationExpression: string;
+    recipientDelayExpression: string;
     messageValidationExpression: string;
+    messageDelayExpression: string;
     disableIPv6: string;
     users: User[];
     relayTlsMode: string | undefined;

--- a/Rnwood.Smtp4dev/ClientApp/src/components/settingsdialog.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/settingsdialog.vue
@@ -146,11 +146,28 @@
                                 </template>
                             </el-input>
                         </el-form-item>
+                        
+                        <el-form-item label="Recipient delay expression (see comments in appsettings.json)" prop="server.recipientDelayExpression">
+
+                            <el-input v-model="server.recipientDelayExpression" :disabled="server.lockedSettings.recipientDelayExpression">
+                                <template #prefix>
+                                    <el-icon v-if="server.lockedSettings.recipientDelayExpression" :title="`Locked: ${server.lockedSettings.recipientDelayExpression}`"><Lock /></el-icon>
+                                </template>
+                            </el-input>
+                        </el-form-item>
 
                         <el-form-item label="Message validation expression (see comments in appsettings.json)" prop="server.messageValidationExpression">
                             <el-input v-model="server.messageValidationExpression" :disabled="server.lockedSettings.messageValidationExpression">
                                 <template #prefix>
                                     <el-icon v-if="server.lockedSettings.messageValidationExpression" :title="`Locked: ${server.lockedSettings.messageValidationExpression}`"><Lock /></el-icon>
+                                </template>
+                            </el-input>
+                        </el-form-item>
+                        
+                        <el-form-item label="Message delay expression (see comments in appsettings.json)" prop="server.messageDelayExpression">
+                            <el-input v-model="server.messageDelayExpression" :disabled="server.lockedSettings.messageDelayExpression">
+                                <template #prefix>
+                                    <el-icon v-if="server.lockedSettings.messageDelayExpression" :title="`Locked: ${server.lockedSettings.messageDelayExpression}`"><Lock /></el-icon>
                                 </template>
                             </el-input>
                         </el-form-item>

--- a/Rnwood.Smtp4dev/Controllers/ServerController.cs
+++ b/Rnwood.Smtp4dev/Controllers/ServerController.cs
@@ -93,7 +93,9 @@ namespace Rnwood.Smtp4dev.Controllers
                 SecureConnectionRequired = serverOptionsCurrentValue.SecureConnectionRequired,
                 CredentialsValidationExpression = serverOptionsCurrentValue.CredentialsValidationExpression,
                 RecipientValidationExpression = serverOptionsCurrentValue.RecipientValidationExpression,
+                RecipientDelayExpression = serverOptionsCurrentValue.RecipientDelayExpression,
                 MessageValidationExpression = serverOptionsCurrentValue.MessageValidationExpression,
+                MessageDelayExpression = serverOptionsCurrentValue.MessageDelayExpression,
                 DisableIPv6 = serverOptionsCurrentValue.DisableIPv6,
                 WebAuthenticationRequired = serverOptionsCurrentValue.WebAuthenticationRequired,
                 Users = serverOptionsCurrentValue.Users,
@@ -220,7 +222,9 @@ namespace Rnwood.Smtp4dev.Controllers
             newSettings.SecureConnectionRequired = serverUpdate.SecureConnectionRequired;
             newSettings.CredentialsValidationExpression = serverUpdate.CredentialsValidationExpression;
             newSettings.RecipientValidationExpression = serverUpdate.RecipientValidationExpression;
+            newSettings.RecipientDelayExpression = serverUpdate.RecipientDelayExpression;
             newSettings.MessageValidationExpression = serverUpdate.MessageValidationExpression;
+            newSettings.MessageDelayExpression = serverUpdate.MessageDelayExpression;
             newSettings.DisableIPv6 = serverUpdate.DisableIPv6;
             newSettings.Users = serverUpdate.Users;
 			newSettings.Mailboxes = serverUpdate.Mailboxes;

--- a/Rnwood.Smtp4dev/Server/Settings/ServerOptions.cs
+++ b/Rnwood.Smtp4dev/Server/Settings/ServerOptions.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net;
-using Esprima.Ast;
 
 namespace Rnwood.Smtp4dev.Server.Settings
 {
@@ -39,8 +38,11 @@ namespace Rnwood.Smtp4dev.Server.Settings
 
         public bool SmtpAllowAnyCredentials { get; set; }
         public string RecipientValidationExpression { get; set; }
+        public string RecipientDelayExpression { get; set; }
 
         public string MessageValidationExpression { get; set; }
+        public string MessageDelayExpression { get; set; }
+
         public bool DisableIPv6 { get; set; } = false;
 
         public UserOptions[] Users { get; set; } = [];

--- a/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
@@ -114,6 +114,9 @@ namespace Rnwood.Smtp4dev.Server
             var session = dbContext.Sessions.AsNoTracking().Single(s => s.Id == sessionId);
             var apiSession = new ApiModel.Session(session);
 
+            var delay = scriptingHost.DelayRecipient(apiSession, e.Recipient);
+            Task.Delay(delay).Wait();
+
             if (!this.scriptingHost.ValidateRecipient(apiSession, e.Recipient))
             {
                 throw new SmtpServerException(new SmtpResponse(StandardSmtpResponseCode.RecipientRejected, "Recipient rejected"));
@@ -160,6 +163,9 @@ namespace Rnwood.Smtp4dev.Server
             Session dbSession = dbContext.Sessions.Find(activeSessionsToDbId[e.Connection.Session]);
 
             var apiSession = new ApiModel.Session(dbSession);
+
+            var delay = scriptingHost.DelayMessage(apiMessage, apiSession);
+            Task.Delay(delay).Wait();
 
             var errorResponse = scriptingHost.ValidateMessage(apiMessage, apiSession);
 

--- a/Rnwood.Smtp4dev/appsettings.json
+++ b/Rnwood.Smtp4dev/appsettings.json
@@ -127,6 +127,17 @@
     // - Rejects this recipient only
     "RecipientValidationExpression": "",
 
+    // A JavaScript expression used to delay the process of adding a recipient 
+    // The return value is a number that will be used as the delay in milliseconds
+    // The variable 'recipient' refers to the current recipient (one call per recipient)
+    // The variable `session` refers to the the current session:
+    // For available properties see https://github.com/rnwood/smtp4dev/blob/master/Rnwood.Smtp4dev/ApiModel/Session.cs
+    //
+    // Examples
+    // recipient == "foo@bar.com" ? 3000 : 0
+    // - Delay adding this recipient by 3 seconds
+    "RecipientDelayExpression": "",
+
     // A JavaScript expression used to validate message to determine if the server will accept it.
     // The return value is a boolean value where true will accept the message.
     //If the return value is a number it will be used as response code
@@ -142,6 +153,17 @@
     // message.subject.includes("19") ? 441 : null
     // - Rejects messages that include 19 with a 441, otherwise accepts
     "MessageValidationExpression": "",
+
+    // A JavaScript expression used to delay message acceptance
+    // The return value is a number that will be used as the delay in milliseconds
+    // The variable 'message' refers to the current message   
+    // For available properties see https://github.com/rnwood/smtp4dev/blob/master/Rnwood.Smtp4dev/ApiModel/Message.cs
+    // The variable `session` refers to the the current session:
+    // For available properties see https://github.com/rnwood/smtp4dev/blob/master/Rnwood.Smtp4dev/ApiModel/Session.cs
+    // Examples
+    // message.subject.includes("19") ? 3000 : 0
+    // - Delay messages that include 19 for 3 seconds, otherwise no delay is added.
+    "MessageDelayExpression": "",
 
     //True if web interface and API will need BASIC auth.
     //See 'Users'


### PR DESCRIPTION
Hi, 

this PR adds two new options to smtp4dev: RecipientDelayExpression and MessageDelayExpression. These expressions can be used to create an artificial delay when adding a recipient or adding a message. 
We want to use this feature to create failure situations for mail related software. This way, we can simulate a slow or misbehaving mail server better and check if our handling of delays and timeouts is proper and reliable.
If you want any changes or have a different idea how to implement this, just let me know.