### PR TITLE
Fix to StackOverflow when 3000 of and/or rules

### DIFF
--- a/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
+++ b/Rnwood.Smtp4dev/Rnwood.Smtp4dev.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="DotNet.Glob" Version="3.1.3" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="Jint" Version="3.0.1" />
+    <PackageReference Include="Linq.Expression.Optimizer" Version="1.0.23" />
     <PackageReference Include="LinqKit" Version="1.2.5" />
     <PackageReference Include="MailKit" Version="4.6.0" />
      <PackageReference Include="Microsoft.AspNetCore.Hosting.WindowsServices" Version="8.0.6" />

--- a/Rnwood.Smtp4dev/Server/Imap/ImapSearchTranslator.cs
+++ b/Rnwood.Smtp4dev/Server/Imap/ImapSearchTranslator.cs
@@ -51,7 +51,7 @@ namespace Rnwood.Smtp4dev.Server.Imap
 
         private Expression<Func<Message, bool>> HandleOr(IMAP_Search_Key_Or or) { 
         
-            return Translate(or.SearchKey1).Or(Translate(or.SearchKey2));
+            return ExpressionOptimizer.tryVisitTyped(Translate(or.SearchKey1).Or(Translate(or.SearchKey2)).Expand());
         }
 
         private string EscapeLike(string text)
@@ -63,7 +63,7 @@ namespace Rnwood.Smtp4dev.Server.Imap
         {
             string like = $"%{EscapeLike(text)}%";
             Expression<Func<Message, bool>> expression = m => EF.Functions.Like(property.Invoke(m), like);
-            return expression.Expand();
+            return ExpressionOptimizer.tryVisitTyped(expression.Expand());
         }
 
         private Expression<Func<Message, bool>> HandleSubject(IMAP_Search_Key_Subject subject)
@@ -84,7 +84,7 @@ namespace Rnwood.Smtp4dev.Server.Imap
         private Expression<Func<Message, bool>> HandleNot(IMAP_Search_Key_Not not)
         {
             Expression<Func<Message, bool>> query = (m => !Translate(not.SearchKey).Invoke(m));
-            return query.Expand();
+            return ExpressionOptimizer.tryVisitTyped(query.Expand());
         }
 
         private Expression<Func<Message, bool>> HandleSeen(IMAP_Search_Key_Seen seen)
@@ -105,8 +105,7 @@ namespace Rnwood.Smtp4dev.Server.Imap
             {
                 result = result.And(Translate(key));
             }
-
-            return result;
+            return ExpressionOptimizer.tryVisitTyped(result.Expand());
         }
     }
 


### PR DESCRIPTION
Hi,

This PR fixes possible StackOverflow when a lot of and/or-rules in the expression trees.
In real life you hopefully don't have so many, unless you fake MailChimp or other marketing tool.
