### PR TITLE
Fix mailbox cli argument parsing and improve documentation

### DIFF
--- a/Rnwood.Smtp4dev/CommandLineParser.cs
+++ b/Rnwood.Smtp4dev/CommandLineParser.cs
@@ -61,7 +61,7 @@ namespace Rnwood.Smtp4dev
                 { "SmtpAuthTypesSecure=", "SMTP auth type enabled when  using secure connection (choices: ANONYMOUS, PLAIN, LOGIN, CRAM-MD5). Separate values with comma.", data =>
                        map.Add(data, x => x.ServerOptions.SmtpEnabledAuthTypesWhenSecureConnection) },
                 { "mailbox=", "Adds a mailbox in Name=Recipients format (Recipients can contain comma separated wildcards or regex)see appsettings for more details). This option can be repeated to add multiple users.", data =>
-                       map.Add(data, x => x.ServerOptions.Users)},
+                       map.Add(data, x => x.ServerOptions.Mailboxes)},
                 {"sslprotocols=", "Specifies the SSL/TLS protocol version(s) that will be allowed. Separate with commas. See https://learn.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=net-9.0", data => map.Add(data, x => x.ServerOptions.SslProtocols)  },
                 {"tlsciphersuites=", "Specifies the TLS cipher suites to be allowed. Not supported on Windows. Separate with commas. See https://learn.microsoft.com/en-us/dotnet/api/system.net.security.tlsciphersuite?view=net-9.0", data => map.Add(data, x => x.ServerOptions.TlsCipherSuites) }
 

--- a/Rnwood.Smtp4dev/Server/Settings/MailboxOptions.cs
+++ b/Rnwood.Smtp4dev/Server/Settings/MailboxOptions.cs
@@ -30,7 +30,7 @@ namespace Rnwood.Smtp4dev.Server.Settings
 
             if (values.Length != 2)
             {
-                throw new FormatException("Mailbox must be in format \"Name:Recipients\"");
+                throw new FormatException("Mailbox must be in format \"Name=Recipients\"");
             }
 
             return new MailboxOptions { Name = values[0], Recipients = values[1]};

--- a/Rnwood.Smtp4dev/Server/Settings/UserOptions.cs
+++ b/Rnwood.Smtp4dev/Server/Settings/UserOptions.cs
@@ -28,7 +28,7 @@ namespace Rnwood.Smtp4dev.Server.Settings
             string[] values = stringValue.Split('=', 2);
 
             if (values.Length != 2) {
-                throw new FormatException("User must be in format \"Username:Password\"");
+                throw new FormatException("User must be in format \"Username=Password\"");
             }
 
             return new UserOptions { Username = values[0], Password = values[1] };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,9 @@ services:
       #Specifies the TLS certificate to use if TLS is enabled/requested. Specify "" to use an auto-generated self-signed certificate (then see console output on first startup)
       #- ServerOptions__TlsCertificate=
 
+      #Specifies a mailbox with name "Test" and recipient "hello@world.com". To add more, use the same format but replace the number at the end of the variable name.
+      #- ServerOptions__Mailboxes__0=Test=hello@world.com
+
       #Sets the name of the SMTP server that will be used to relay messages or "" if messages should not be relayed
       #- RelayOptions__SmtpServer=
 


### PR DESCRIPTION
This PR fixes #1694. I am not really versed in C#, but I thought I provide what I hope to be the fix, since I was looking into the code anyways, to figure out how to add the mailboxes on startup without having to add a custom file.

Sorry for not adding any tests, but as I said, I don't have any experience with C#. Feel free to add and adjust as you feel appropriate.

* Adds the data passed to `mailbox=` to the Mailboxes
* Changes the error message for the TypeConverter for MailboxSettings and UserSettings
* Adds a hint on how to add mailboxes via EnvironmentVariable (which already worked, but since it's a bit of a more complicated case deserves an example, IMO)