### PR TITLE
Add MaximumMessageSize configuration option

### DIFF
--- a/Rnwood.Smtp4dev/CommandLineParser.cs
+++ b/Rnwood.Smtp4dev/CommandLineParser.cs
@@ -62,9 +62,10 @@ namespace Rnwood.Smtp4dev
                        map.Add(data, x => x.ServerOptions.SmtpEnabledAuthTypesWhenSecureConnection) },
                 { "mailbox=", "Adds a mailbox in Name=Recipients format (Recipients can contain comma separated wildcards or regex)see appsettings for more details). This option can be repeated to add multiple users.", data =>
                        map.Add(data, x => x.ServerOptions.Mailboxes)},
-                {"sslprotocols=", "Specifies the SSL/TLS protocol version(s) that will be allowed. Separate with commas. See https://learn.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=net-9.0", data => map.Add(data, x => x.ServerOptions.SslProtocols)  },
-                {"tlsciphersuites=", "Specifies the TLS cipher suites to be allowed. Not supported on Windows. Separate with commas. See https://learn.microsoft.com/en-us/dotnet/api/system.net.security.tlsciphersuite?view=net-9.0", data => map.Add(data, x => x.ServerOptions.TlsCipherSuites) },
-                {"HtmlValidateConfigfile=", "Defines path to a config file used for HTML validation. See https://html-validate.org/usage/index.html#configuration", data => map.Add(File.ReadAllText(data), x => x.ServerOptions.HtmlValidateConfig) }
+                { "sslprotocols=", "Specifies the SSL/TLS protocol version(s) that will be allowed. Separate with commas. See https://learn.microsoft.com/en-us/dotnet/api/system.security.authentication.sslprotocols?view=net-9.0", data => map.Add(data, x => x.ServerOptions.SslProtocols)  },
+                { "tlsciphersuites=", "Specifies the TLS cipher suites to be allowed. Not supported on Windows. Separate with commas. See https://learn.microsoft.com/en-us/dotnet/api/system.net.security.tlsciphersuite?view=net-9.0", data => map.Add(data, x => x.ServerOptions.TlsCipherSuites) },
+                { "HtmlValidateConfigfile=", "Defines path to a config file used for HTML validation. See https://html-validate.org/usage/index.html#configuration", data => map.Add(File.ReadAllText(data), x => x.ServerOptions.HtmlValidateConfig) },
+                { "maxmessagesize=", "Defines the maximum message size in bytes accepted by the SMTP server", data => map.Add(data, x => x.ServerOptions.MaxMessageSize) }
             };
 
             if (!isDesktopApp)

--- a/Rnwood.Smtp4dev/Server/Settings/ServerOptions.cs
+++ b/Rnwood.Smtp4dev/Server/Settings/ServerOptions.cs
@@ -69,6 +69,8 @@ namespace Rnwood.Smtp4dev.Server.Settings
         public MailboxOptions[] Mailboxes { get; set; } = [];
 
         public string HtmlValidateConfig { get; set; }
+
+        public long? MaxMessageSize { get; set; }
     }
 
 }

--- a/Rnwood.Smtp4dev/Server/Settings/ServerOptionsSource.cs
+++ b/Rnwood.Smtp4dev/Server/Settings/ServerOptionsSource.cs
@@ -67,6 +67,6 @@ namespace Rnwood.Smtp4dev.Server.Settings
 
         public string HtmlValidateConfig { get; set; }
 
-
+        public long? MaxMessageSize { get; set; }
     }
 }

--- a/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
@@ -97,8 +97,8 @@ namespace Rnwood.Smtp4dev.Server
                 serverOptionsValue.TlsMode == TlsMode.ImplicitTls ? cert : null,
             serverOptionsValue.TlsMode == TlsMode.StartTls ? cert : null,
                 !string.IsNullOrWhiteSpace(serverOptionsValue.SslProtocols) ? serverOptionsValue.SslProtocols.Split(",", StringSplitOptions.RemoveEmptyEntries|StringSplitOptions.TrimEntries).Select(s => Enum.Parse<SslProtocols>(s, true)).Aggregate((current, protocol) => current | protocol) : SslProtocols.None,
-                !string.IsNullOrWhiteSpace(serverOptionsValue.TlsCipherSuites) ? serverOptionsValue.TlsCipherSuites.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(s => Enum.Parse<TlsCipherSuite>(s, true)).ToArray() : null
-
+                !string.IsNullOrWhiteSpace(serverOptionsValue.TlsCipherSuites) ? serverOptionsValue.TlsCipherSuites.Split(",", StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Select(s => Enum.Parse<TlsCipherSuite>(s, true)).ToArray() : null,
+                serverOptionsValue.MaxMessageSize
             ));
             this.smtpServer.MessageCompletedEventHandler += OnMessageCompleted;
             this.smtpServer.MessageReceivedEventHandler += OnMessageReceived;

--- a/Rnwood.Smtp4dev/appsettings.json
+++ b/Rnwood.Smtp4dev/appsettings.json
@@ -212,8 +212,10 @@
     "HtmlValidateConfig": "{ \"$schema\": \"https://html-validate.org/schemas/config.json\", \"extends\": [ \"html-validate:recommended\" ]}",
 
     // The MaxMessageSize option configures the SIZE header
-    // This header is returned by the server during the HELO/EHLO handshake
-    "MaxMessageSize": -15
+    // The SIZE extension is always enabled, this option merely configures an maximum message size (in bytes) that is accepted by the server.
+    // When the option is non-negative, the optional parameter is added to the SIZE header (i.e. SIZE=12345).
+    // Otherwise the optional parameter is omitted.
+    "MaxMessageSize": null
   },
 
     "RelayOptions": {

--- a/Rnwood.Smtp4dev/appsettings.json
+++ b/Rnwood.Smtp4dev/appsettings.json
@@ -209,8 +209,11 @@
 
     // Defines the config used for HTML validation
     // See https://html-validate.org/usage/index.html#configuration
-    "HtmlValidateConfig": "{ \"$schema\": \"https://html-validate.org/schemas/config.json\", \"extends\": [ \"html-validate:recommended\" ]}"
-    
+    "HtmlValidateConfig": "{ \"$schema\": \"https://html-validate.org/schemas/config.json\", \"extends\": [ \"html-validate:recommended\" ]}",
+
+    // The MaxMessageSize option configures the SIZE header
+    // This header is returned by the server during the HELO/EHLO handshake
+    "MaxMessageSize": -15
   },
 
     "RelayOptions": {

--- a/smtpserver/Rnwood.SmtpServer.Tests/ClientTests.cs
+++ b/smtpserver/Rnwood.SmtpServer.Tests/ClientTests.cs
@@ -55,7 +55,7 @@ public partial class ClientTests
     [Fact]
     public async Task MailKit_SmtpUtf8()
     {
-        using (SmtpServer server = new SmtpServer(new Rnwood.SmtpServer.ServerOptions(false, false, "test", (int)StandardSmtpPort.AssignAutomatically, false, [], [], null, null, SslProtocols.None, new System.Net.Security.TlsCipherSuite[]{ })))
+        using (SmtpServer server = new SmtpServer(new Rnwood.SmtpServer.ServerOptions(false, false, "test", (int)StandardSmtpPort.AssignAutomatically, false, [], [], null, null, SslProtocols.None, new System.Net.Security.TlsCipherSuite[]{ }, null)))
         {
             ConcurrentBag<IMessage> messages = new ConcurrentBag<IMessage>();
 
@@ -83,7 +83,7 @@ public partial class ClientTests
     [Fact]
     public async Task MailKit_NonSSL()
     {
-        using (SmtpServer server = new SmtpServer(new Rnwood.SmtpServer.ServerOptions(false, false, "test",(int)StandardSmtpPort.AssignAutomatically, false, [], [], null, null, SslProtocols.None, null)))
+        using (SmtpServer server = new SmtpServer(new Rnwood.SmtpServer.ServerOptions(false, false, "test",(int)StandardSmtpPort.AssignAutomatically, false, [], [], null, null, SslProtocols.None, null, null)))
         {
             ConcurrentBag<IMessage> messages = new ConcurrentBag<IMessage>();
 
@@ -111,7 +111,7 @@ public partial class ClientTests
     {
         using (SmtpServer server = new SmtpServer(new Rnwood.SmtpServer.ServerOptions( false,false, Dns.GetHostName(),
                    (int)StandardSmtpPort.AssignAutomatically, false, [], [],
-                   null, CreateSelfSignedCertificate(), SslProtocols.None, null)))
+                   null, CreateSelfSignedCertificate(), SslProtocols.None, null, null)))
         {
             ConcurrentBag<IMessage> messages = new ConcurrentBag<IMessage>();
 
@@ -139,7 +139,7 @@ public partial class ClientTests
     {
         using (SmtpServer server = new SmtpServer(new Rnwood.SmtpServer.ServerOptions( false,false, Dns.GetHostName(),
                    (int)StandardSmtpPort.AssignAutomatically, false, [], [],
-                   CreateSelfSignedCertificate(), null, SslProtocols.None, null)))
+                   CreateSelfSignedCertificate(), null, SslProtocols.None, null, null)))
         {
             ConcurrentBag<IMessage> messages = new ConcurrentBag<IMessage>();
 
@@ -166,7 +166,7 @@ public partial class ClientTests
     [Fact]
     public async Task MailKit_NonSSL_StressTest()
     {
-        using (SmtpServer server = new SmtpServer(new Rnwood.SmtpServer.ServerOptions( false, false, "test", (int) StandardSmtpPort.AssignAutomatically, false, [], [], null, null, SslProtocols.None, null)))
+        using (SmtpServer server = new SmtpServer(new Rnwood.SmtpServer.ServerOptions( false, false, "test", (int) StandardSmtpPort.AssignAutomatically, false, [], [], null, null, SslProtocols.None, null, null)))
         {
             ConcurrentBag<IMessage> messages = new ConcurrentBag<IMessage>();
 

--- a/smtpserver/Rnwood.SmtpServer.Tests/ServerTests.cs
+++ b/smtpserver/Rnwood.SmtpServer.Tests/ServerTests.cs
@@ -109,7 +109,7 @@ public class ServerTests
     [Fact]
     public void StartOnAutomaticPort_PortNumberReturned()
     {
-        SmtpServer server = new SmtpServer(new ServerOptions(false, false, "test", (int)StandardSmtpPort.AssignAutomatically, true, [], [], null, null, System.Security.Authentication.SslProtocols.None, null));
+        SmtpServer server = new SmtpServer(new ServerOptions(false, false, "test", (int)StandardSmtpPort.AssignAutomatically, true, [], [], null, null, System.Security.Authentication.SslProtocols.None, null, null));
         server.Start();
         Assert.NotEqual(0, server.ListeningEndpoints.First().Port);
     }
@@ -125,11 +125,11 @@ public class ServerTests
         //all the connections.
         Skip.IfNot(Environment.OSVersion.Platform == PlatformID.Win32NT);
 
-        using (SmtpServer server1 = new SmtpServer(new Rnwood.SmtpServer.ServerOptions(false, false, "test", (int)StandardSmtpPort.AssignAutomatically, true, [], [], null, null,SslProtocols.None, null)))
+        using (SmtpServer server1 = new SmtpServer(new Rnwood.SmtpServer.ServerOptions(false, false, "test", (int)StandardSmtpPort.AssignAutomatically, true, [], [], null, null,SslProtocols.None, null, null)))
         {
             server1.Start();
 
-            using (SmtpServer server2 = new SmtpServer(new Rnwood.SmtpServer.ServerOptions(false, false, "test", server1.ListeningEndpoints.First().Port, true, [], [], null, null, SslProtocols.None, null)))
+            using (SmtpServer server2 = new SmtpServer(new Rnwood.SmtpServer.ServerOptions(false, false, "test", server1.ListeningEndpoints.First().Port, true, [], [], null, null, SslProtocols.None, null, null)))
             {
                 Assert.Throws<SocketException>(() => { server2.Start(); });
             }
@@ -224,7 +224,7 @@ public class ServerTests
     /// <summary>
     /// </summary>
     /// <returns>The <see cref="SmtpServer" /></returns>
-    private SmtpServer NewServer(bool allowRemoteConnections, bool allowIpV6) => new SmtpServer(new Rnwood.SmtpServer.ServerOptions(allowRemoteConnections, allowIpV6, "test", (int)StandardSmtpPort.AssignAutomatically, false, [], [], null, null, SslProtocols.None, null));
+    private SmtpServer NewServer(bool allowRemoteConnections, bool allowIpV6) => new SmtpServer(new Rnwood.SmtpServer.ServerOptions(allowRemoteConnections, allowIpV6, "test", (int)StandardSmtpPort.AssignAutomatically, false, [], [], null, null, SslProtocols.None, null, null));
 
     /// <summary>
     /// </summary>

--- a/smtpserver/Rnwood.SmtpServer/ServerOptions.cs
+++ b/smtpserver/Rnwood.SmtpServer/ServerOptions.cs
@@ -34,7 +34,7 @@ public class ServerOptions : IServerOptions
     private readonly X509Certificate startTlsCertificate;
     private readonly SslProtocols sslProtocols;
     private readonly TlsCipherSuite[] tlsCipherSuites;
-
+    private readonly long? maxMessageSize;
 
     /// <summary>
     ///     Initializes a new instance of the <see cref="ServerOptions" /> class.
@@ -49,7 +49,8 @@ public class ServerOptions : IServerOptions
     /// <param name="implcitTlsCertificate">The TLS certificate to use for implicit TLS.</param>
     /// <param name="startTlsCertificate">The TLS certificate to use for STARTTLS.</param>
     /// <param name="sslProtocols">The SSL protocol versions to allow</param>
-    ///     /// <param name="tlsCipherSuites">The TLS cipher suites to allow</param>
+    /// <param name="tlsCipherSuites">The TLS cipher suites to allow</param>
+    /// <param name="maxMessageSize">The maximum message size in bytes accepted by the server</param>
     public ServerOptions(
         bool allowRemoteConnections,
         bool enableIpV6,
@@ -61,7 +62,8 @@ public class ServerOptions : IServerOptions
         X509Certificate implcitTlsCertificate,
         X509Certificate startTlsCertificate,
         SslProtocols sslProtocols,
-        TlsCipherSuite[] tlsCipherSuites)
+        TlsCipherSuite[] tlsCipherSuites,
+        long? maxMessageSize)
     {
         DomainName = domainName;
         PortNumber = portNumber;
@@ -74,6 +76,7 @@ public class ServerOptions : IServerOptions
         this.secureAuthMechanismIds = secureAuthMechanismNamesIds ?? throw new ArgumentNullException(nameof(secureAuthMechanismNamesIds));
         this.sslProtocols = sslProtocols;
         this.tlsCipherSuites = tlsCipherSuites;
+        this.maxMessageSize = maxMessageSize;
     }
 
 
@@ -129,7 +132,8 @@ public class ServerOptions : IServerOptions
     }
 
     /// <inheritdoc />
-    public virtual Task<long?> GetMaximumMessageSize(IConnection connection) => Task.FromResult<long?>(null);
+    public virtual Task<long?> GetMaximumMessageSize(IConnection connection) =>
+        Task.FromResult(maxMessageSize >= 0 ? maxMessageSize : null);
 
     /// <inheritdoc />
     public virtual Task<TimeSpan> GetReceiveTimeout(IConnectionChannel connectionChannel) =>

--- a/smtpserver/Rnwood.SmtpServer/Verbs/DataVerb.cs
+++ b/smtpserver/Rnwood.SmtpServer/Verbs/DataVerb.cs
@@ -71,10 +71,8 @@ public class DataVerb : IVerb
         long? maxMessageSize =
             await connection.Server.Options.GetMaximumMessageSize(connection).ConfigureAwait(false);
 
-
-
-
-        if (maxMessageSize.HasValue && messageSize > maxMessageSize.Value)
+        bool shouldValidateMessageSize = maxMessageSize.HasValue && maxMessageSize > 0;
+        if (shouldValidateMessageSize && messageSize > maxMessageSize.Value)
         {
             await connection.WriteResponse(
                 new SmtpResponse(
@@ -82,9 +80,7 @@ public class DataVerb : IVerb
                     "Message exceeds fixed size limit")).ConfigureAwait(false);
             await connection.AbortMessage().ConfigureAwait(false);
             return;
-
         }
-
 
         try
         {


### PR DESCRIPTION
As reported in #1615 the SIZE extension could not be configured in current versions of smtp4dev.

I opted to use a single option to allow configuring the optional SIZE parameter.

A next step could be to make the SIZE extension fully optional.
To fully support the spec this would mean using 2 options
- SizeEnabled, whether it is available or not
- MaxMessageSize, for the optional parameter

