### PR TITLE
feat: add mailbox sorting by name

### DIFF
--- a/Rnwood.Smtp4dev/ClientApp/src/components/messagelist.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/messagelist.vue
@@ -537,7 +537,8 @@
                 const server = await this.connection!.getServer()
                 this.isRelayAvailable = !!server.relaySmtpServer;
 
-                this.availableMailboxes = await new MailboxesController().getAll();
+                const mailboxes = await new MailboxesController().getAll();
+                this.availableMailboxes = mailboxes.sort((a, b) => a.name.localeCompare(b.name));
                 if (!this.selectedMailbox) {
                     this.selectedMailbox = this.availableMailboxes.find(m => m.name == server.currentUserDefaultMailboxName)?.name ?? this.availableMailboxes[this.availableMailboxes.length - 1]?.name ?? null;
                 } else {


### PR DESCRIPTION
### Summary

Mailboxes are currently sorted by their GUID, which becomes confusing and impractical when working with a larger number of mailboxes.

### Change

This pull request updates the sorting logic to order mailboxes by their name instead, improving readability and usability.