### PR TITLE
fix: check header filters before user's default mailbox

### DIFF
--- a/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
+++ b/Rnwood.Smtp4dev/Server/Smtp4devServer.cs
@@ -578,6 +578,31 @@ namespace Rnwood.Smtp4dev.Server
         {
             if (serverOptions.CurrentValue.DeliverMessagesToUsersDefaultMailbox && messageSession.Authenticated && messageSession.AuthenticationCredentials is IAuthenticationCredentialsCanValidateWithPassword credentials)
             {
+                // Check header filters first - they take priority over user's default mailbox
+                bool headersNeededForUser = serverOptions.CurrentValue.Mailboxes.Any(m => m.HeaderFilters != null && m.HeaderFilters.Length > 0);
+                if (headersNeededForUser)
+                {
+                    var headerFilteredMailboxes = serverOptions.CurrentValue.Mailboxes
+                        .Where(m => m.HeaderFilters != null && m.HeaderFilters.Length > 0);
+
+                    if (headerFilteredMailboxes.Any())
+                    {
+                        var userMessageHeaders = await ParseMessageHeaders(message);
+                        var allMailboxes = serverOptions.CurrentValue.Mailboxes.Concat(new[] { new MailboxOptions { Name = MailboxOptions.DEFAULTNAME, Recipients = "*" } });
+
+                        foreach (var to in recipients)
+                        {
+                            var headerMatch = mailboxRouter.FindMailboxForRecipient(to, headerFilteredMailboxes, userMessageHeaders);
+                            if (headerMatch != null)
+                            {
+                                // Header filter matched - route all recipients to that mailbox
+                                return recipients.ToLookup(_ => headerMatch, recipient => recipient);
+                            }
+                        }
+                    }
+                }
+
+                // No header filter matched - fall back to user's default mailbox
                 UserOptions userOptions = serverOptions.CurrentValue.Users.FirstOrDefault(u => string.Equals(u.Username, credentials.Username, StringComparison.OrdinalIgnoreCase));
                 MailboxOptions defaultMailboxOptions = new MailboxOptions { Name = MailboxOptions.DEFAULTNAME, Recipients = "*" };
                 MailboxOptions mailboxOption = defaultMailboxOptions;


### PR DESCRIPTION
## Summary

- When `DeliverMessagesToUsersDefaultMailbox` is enabled, header filters are now checked **before** falling back to the user's default mailbox
- If a mailbox with matching `HeaderFilters` is found, the message is routed there
- If no header filter matches, behavior is unchanged (user's default mailbox)
- Fully backward compatible: no behavior change when no `HeaderFilters` are configured

## Use Case

Multiple subsystems share the same SMTP credentials but add custom headers to identify themselves:

```json
{
  "DeliverMessagesToUsersDefaultMailbox": true,
  "Users": [
    { "Username": "USOSapi", "DefaultMailbox": "USOSapi" }
  ],
  "Mailboxes": [
    {
      "Name": "SRS",
      "Recipients": "*",
      "HeaderFilters": [
        { "Header": "X-Application", "Pattern": "srs" }
      ]
    },
    { "Name": "USOSapi", "Recipients": "*" }
  ]
}
```

**Before**: All emails from USOSapi go to USOSapi mailbox regardless of headers.
**After**: Emails with `X-Application: srs` go to SRS mailbox; others go to USOSapi.

## Test plan

- [ ] Email with matching header filter → routed to header-matched mailbox
- [ ] Email without matching headers → routed to user's default mailbox (unchanged)
- [ ] No header filters configured → behavior unchanged
- [ ] Unauthenticated email → header filters work as before via MailboxRouter

Fixes #2054