### PR TITLE
fix: dark mode support for mailbox settings UI

### DIFF
--- a/Rnwood.Smtp4dev/ClientApp/src/components/settingsdialog.vue
+++ b/Rnwood.Smtp4dev/ClientApp/src/components/settingsdialog.vue
@@ -422,10 +422,10 @@
 
 
 
-                        <div v-for="(mailbox, index) in server.mailboxes" :key="index" style="margin-bottom: 20px; padding: 15px; border: 2px solid #e4e7ed; border-radius: 8px; background-color: #fafafa; position: relative;">
+                        <div v-for="(mailbox, index) in server.mailboxes" :key="index" class="mailbox-card">
                             <el-form-item :prop="'server.mailboxes[' + index + ']'" :rules="{validator: checkMailboxNameUnique}">
                                 <!-- Mailbox Header with Order Controls -->
-                                <div style="display: flex; gap: 10px; align-items: center; margin-bottom: 15px; padding-bottom: 10px; border-bottom: 1px solid #dcdfe6;">
+                                <div class="mailbox-header">
                                     <el-button @click="server.mailboxes.splice(index, 1); server.mailboxes.splice(index-1, 0, mailbox);" :disabled="server.lockedSettings.mailboxes || index==0" title="Move up">
                                         <el-icon><ArrowUp /></el-icon>
                                     </el-button>
@@ -461,8 +461,8 @@
                                             <el-input v-model="mailbox.recipients" :disabled="server.lockedSettings.mailboxes" placeholder="e.g., *@example.com">
                                             </el-input>
                                         </el-form-item>
-                                        <div style="font-size: 11px; color: #606266; margin-top: 4px; padding-left: 4px;">
-                                            💡 Exact: <code>user@example.com</code> | Wildcard: <code>*@example.com</code> | Regex: <code>/pattern/</code>
+                                        <div class="filter-hint">
+                                            Exact: <code>user@example.com</code> | Wildcard: <code>*@example.com</code> | Regex: <code>/pattern/</code>
                                         </div>
                                     </div>
                                     
@@ -473,12 +473,12 @@
                                             Headers (optional)
                                         </div>
                                         
-                                        <div v-if="!mailbox.headerFilters || mailbox.headerFilters.length === 0" style="color: #909399; font-style: italic; margin-bottom: 10px; padding: 10px; background-color: #f5f7fa; border-radius: 4px; font-size: 12px;">
+                                        <div v-if="!mailbox.headerFilters || mailbox.headerFilters.length === 0" class="filter-empty">
                                             No header filters
                                         </div>
                                         
                                         <!-- Each Header Filter -->
-                                        <div v-for="(filter, filterIndex) in mailbox.headerFilters" :key="filterIndex" style="margin-bottom: 8px; padding: 10px; border: 1px solid #409eff; border-left-width: 4px; border-radius: 4px; background-color: #ecf5ff;">
+                                        <div v-for="(filter, filterIndex) in mailbox.headerFilters" :key="filterIndex" class="filter-item filter-item--header">
                                             <div style="margin-bottom: 6px;">
                                                 <el-form-item label="Header" :prop="'server.mailboxes[' + index + '].headerFilters[' + filterIndex + '].header'" :rules="{required: true, message: 'Required'}" style="margin-bottom: 4px;">
                                                     <el-input v-model="filter.header" placeholder="e.g., X-Application" :disabled="server.lockedSettings.mailboxes" size="small">
@@ -499,11 +499,11 @@
                                         <el-button size="small" @click="addHeaderFilter(mailbox)" :disabled="server.lockedSettings.mailboxes" style="margin-top: 4px;">
                                             <el-icon><Plus /></el-icon> Add Header
                                         </el-button>
-                                        <div style="font-size: 11px; color: #606266; margin-top: 6px; padding-left: 4px;">
-                                            💡 <code>value</code> | <code>*value*</code> | <code>/regex/</code>
+                                        <div class="filter-hint">
+                                            <code>value</code> | <code>*value*</code> | <code>/regex/</code>
                                         </div>
                                     </div>
-                                    
+
                                     <!-- Source Filters Section -->
                                     <div style="flex: 1; min-width: 280px;">
                                         <div style="font-weight: bold; margin-bottom: 10px; display: flex; align-items: center; gap: 8px;">
@@ -511,12 +511,12 @@
                                             Source (optional)
                                         </div>
                                         
-                                        <div v-if="!mailbox.sourceFilters || mailbox.sourceFilters.length === 0" style="color: #909399; font-style: italic; margin-bottom: 10px; padding: 10px; background-color: #f5f7fa; border-radius: 4px; font-size: 12px;">
+                                        <div v-if="!mailbox.sourceFilters || mailbox.sourceFilters.length === 0" class="filter-empty">
                                             No source filters
                                         </div>
                                         
                                         <!-- Each Source Filter -->
-                                        <div v-for="(filter, filterIndex) in mailbox.sourceFilters" :key="'source-' + filterIndex" style="margin-bottom: 8px; padding: 10px; border: 1px solid #67c23a; border-left-width: 4px; border-radius: 4px; background-color: #f0f9ff;">
+                                        <div v-for="(filter, filterIndex) in mailbox.sourceFilters" :key="'source-' + filterIndex" class="filter-item filter-item--source">
                                             <div style="margin-bottom: 6px;">
                                                 <el-form-item label="Pattern" :prop="'server.mailboxes[' + index + '].sourceFilters[' + filterIndex + '].pattern'" :rules="{required: true, message: 'Required'}" style="margin-bottom: 0;">
                                                     <el-input v-model="filter.pattern" placeholder="e.g., *.example.org, 192.168.*" :disabled="server.lockedSettings.mailboxes" size="small">
@@ -531,8 +531,8 @@
                                         <el-button size="small" @click="addSourceFilter(mailbox)" :disabled="server.lockedSettings.mailboxes" style="margin-top: 4px;">
                                             <el-icon><Plus /></el-icon> Add Source
                                         </el-button>
-                                        <div style="font-size: 11px; color: #606266; margin-top: 6px; padding-left: 4px;">
-                                            💡 <code>host.com</code> | <code>*.example.org</code> | <code>192.168.*</code>
+                                        <div class="filter-hint">
+                                            <code>host.com</code> | <code>*.example.org</code> | <code>192.168.*</code>
                                         </div>
                                     </div>
                                 </div>
@@ -760,3 +760,59 @@
 
     export default toNative(SettingsDialog)
 </script>
+
+<style scoped>
+.mailbox-card {
+    margin-bottom: 20px;
+    padding: 15px;
+    border: 2px solid var(--el-border-color);
+    border-radius: 8px;
+    background-color: var(--el-fill-color-light);
+    position: relative;
+}
+
+.mailbox-header {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    margin-bottom: 15px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--el-border-color-light);
+}
+
+.filter-hint {
+    font-size: 11px;
+    color: var(--el-text-color-secondary);
+    margin-top: 6px;
+    padding-left: 4px;
+}
+
+.filter-empty {
+    color: var(--el-text-color-placeholder);
+    font-style: italic;
+    margin-bottom: 10px;
+    padding: 10px;
+    background-color: var(--el-fill-color-light);
+    border-radius: 4px;
+    font-size: 12px;
+}
+
+.filter-item {
+    margin-bottom: 8px;
+    padding: 10px;
+    border-width: 1px;
+    border-style: solid;
+    border-left-width: 4px;
+    border-radius: 4px;
+}
+
+.filter-item--header {
+    border-color: var(--el-color-primary);
+    background-color: var(--el-color-primary-light-9);
+}
+
+.filter-item--source {
+    border-color: var(--el-color-success);
+    background-color: var(--el-color-success-light-9);
+}
+</style>


### PR DESCRIPTION
## Summary

We tested PR #2061 (AuthenticatedUsers mailbox property) on our deployment and the functionality works correctly - routing by authenticated user, header filters, and source filters all work as expected.

However, we noticed that the Mailboxes tab in Settings dialog has hardcoded light-mode colors in inline styles, which makes it look broken in dark mode (white cards on dark background, unreadable text).

This PR replaces hardcoded color values with Element Plus CSS variables that automatically adapt to the current theme:

- `#fafafa` / `#f5f7fa` → `var(--el-fill-color-light)`
- `#e4e7ed` / `#dcdfe6` → `var(--el-border-color)` / `var(--el-border-color-light)`
- `#606266` / `#909399` → `var(--el-text-color-secondary)` / `var(--el-text-color-placeholder)`
- `#ecf5ff` → `var(--el-color-primary-light-9)` (header filter cards)
- `#f0f9ff` → `var(--el-color-success-light-9)` (source filter cards)
- `#409eff` / `#67c23a` → `var(--el-color-primary)` / `var(--el-color-success)`

Inline styles were extracted to scoped CSS classes for cleaner code.

**Before (dark mode):**
Cards appear as white boxes on dark background with unreadable text.

**After (dark mode):**
Cards properly adapt to the dark theme using Element Plus built-in dark mode variables.

## Related

- Fixes dark mode regression introduced by #2045 and #2050 (header/source filter UI)
- Tested together with #2061

## Test plan

- [x] Verify mailbox cards render correctly in dark mode
- [x] Verify mailbox cards still render correctly in light mode
- [x] Verify header filter items (blue accent) visible in both modes
- [x] Verify source filter items (green accent) visible in both modes
- [x] Verify hint text and empty state placeholders readable in both modes