### PR TITLE
fix(pop3): add NOOP command handler to POP3 server

### DIFF
--- a/Rnwood.Smtp4dev/Server/Pop3/CommandHandlers/NoopCommand.cs
+++ b/Rnwood.Smtp4dev/Server/Pop3/CommandHandlers/NoopCommand.cs
@@ -1,0 +1,21 @@
+namespace Rnwood.Smtp4dev.Server.Pop3.CommandHandlers
+{
+	using System;
+	using System.Threading;
+	using System.Threading.Tasks;
+	using Rnwood.Smtp4dev.Server.Pop3;
+
+	internal class NoopCommand : ICommandHandler
+	{
+		public async Task ExecuteAsync(Pop3SessionContext context, string argument, CancellationToken cancellationToken)
+		{
+			if (!context.Authenticated)
+			{
+				await context.WriteLineAsync("-ERR Not authenticated");
+				return;
+			}
+
+			await context.WriteLineAsync("+OK");
+		}
+	}
+}

--- a/Rnwood.Smtp4dev/Server/Pop3/Pop3Server.cs
+++ b/Rnwood.Smtp4dev/Server/Pop3/Pop3Server.cs
@@ -409,6 +409,7 @@ namespace Rnwood.Smtp4dev.Server.Pop3
 				{"UIDL", GetOverrideOrDefault("UIDL", () => new UidlCommand())},
 				{"DELE", GetOverrideOrDefault("DELE", () => new DeleCommand())},
 				{"RSET", GetOverrideOrDefault("RSET", () => new RsetCommand())},
+				{"NOOP", GetOverrideOrDefault("NOOP", () => new NoopCommand())},
 				{"QUIT", GetOverrideOrDefault("QUIT", () => new QuitCommand())},
 			};
 


### PR DESCRIPTION

First of all, thank you for the fantastic smtp4dev project! 

This pull request adds support for the NOOP (No Operation) command to the POP3 server implementation, enhancing RFC 1939 protocol compliance.

Files Added:

    NoopCommand.cs - New command handler implementing the NOOP operation

Files Modified:

    Pop3Server.cs - Registered NOOP handler in the command handlers dictionary

Implementation Details (from RFC 1939)

```

      NOOP

         Arguments: none

         Restrictions:
             may only be given in the TRANSACTION state

         Discussion:
             The POP3 server does nothing, it merely replies with a
             positive response.

         Possible Responses:
             +OK

         Examples:
             C: NOOP
             S: +OK
             
```