### PR TITLE
fix(api): assign IMAP UID when importing EML message

### DIFF
--- a/Rnwood.Smtp4dev.Tests/Controllers/MessagesControllerTests.cs
+++ b/Rnwood.Smtp4dev.Tests/Controllers/MessagesControllerTests.cs
@@ -478,6 +478,59 @@ namespace Rnwood.Smtp4dev.Tests.Controllers
             Assert.Equal("admin@example.com", result.Results[0].To[1]); // Should NOT have leading space
             Assert.DoesNotContain(result.Results[0].To, email => email.StartsWith(" "));
         }
+
+        [Fact]
+        public async Task ImportMessage_AssignsValidImapUid()
+        {
+            // Arrange
+            var sqliteForTesting = new SqliteInMemory();
+            var context = new Smtp4devDbContext(sqliteForTesting.ContextOptions);
+            context.Database.Migrate();
+
+            var messagesRepository = new MessagesRepository(Substitute.For<ITaskQueue>(), Substitute.For<NotificationsHub>(), context);
+            var messagesController = new MessagesController(messagesRepository, null, new MimeProcessingService());
+
+            string emlContent = @"From: sender@example.com
+To: recipient@example.com
+Subject: Test EML Import
+Date: Wed, 01 Jan 2025 12:00:00 +0000
+Content-Type: text/plain; charset=utf-8
+
+Test body content";
+            byte[] emlBytes = Encoding.UTF8.GetBytes(emlContent);
+
+            var httpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext();
+            httpContext.Request.Body = new MemoryStream(emlBytes);
+            messagesController.ControllerContext = new ControllerContext
+            {
+                HttpContext = httpContext
+            };
+
+            // Act
+            var actionResult = await messagesController.ImportMessage();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(actionResult.Result);
+            Guid messageId = Assert.IsType<Guid>(okResult.Value);
+
+            var dbMessage = await context.Messages.FirstOrDefaultAsync(m => m.Id == messageId);
+            Assert.NotNull(dbMessage);
+            Assert.True(dbMessage.ImapUid >= 1, $"Expected ImapUid >= 1, but got {dbMessage.ImapUid}");
+
+            var imapState = await context.ImapState.FirstOrDefaultAsync();
+            Assert.NotNull(imapState);
+            Assert.Equal(dbMessage.ImapUid, imapState.LastUid);
+
+            // Verify IMAP_MessageInfo creation succeeds with the assigned ImapUid (throws ArgumentException if ImapUid < 1)
+            var imapMsgInfo = new LumiSoft.Net.IMAP.Server.IMAP_MessageInfo(
+                dbMessage.Id.ToString(),
+                dbMessage.ImapUid,
+                new[] { "Seen" },
+                dbMessage.Data.Length,
+                dbMessage.ReceivedDate
+            );
+            Assert.Equal(dbMessage.ImapUid, imapMsgInfo.UID);
+        }
     }
 
 }

--- a/Rnwood.Smtp4dev/Controllers/MessagesController.cs
+++ b/Rnwood.Smtp4dev/Controllers/MessagesController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -603,6 +603,16 @@ namespace Rnwood.Smtp4dev.Controllers
                 dbMessage.Mailbox = mailbox;
                 dbMessage.MailboxFolder = await dbContext.MailboxFolders.FirstOrDefaultAsync(f => f.Mailbox.Name == mailboxName && f.Name == MailboxFolder.INBOX);
                 dbMessage.IsUnread = true;
+
+                var imapState = await dbContext.ImapState.SingleOrDefaultAsync();
+                if (imapState == null)
+                {
+                    imapState = new ImapState { Id = Guid.Empty, LastUid = 0 };
+                    dbContext.ImapState.Add(imapState);
+                }
+
+                imapState.LastUid = Math.Max(0, imapState.LastUid) + 1;
+                dbMessage.ImapUid = imapState.LastUid;
 
                 // Add to database
                 dbContext.Messages.Add(dbMessage);


### PR DESCRIPTION
# Fix IMAP SELECT Error After EML Import (#2116)

Fix issue [#2116](https://github.com/rnwood/smtp4dev/issues/2116) where `SELECT INBOX` fails with `Argument 'uid' value must be >= 1.` after importing an EML file.

## Root Cause Analysis

When a message is imported via the `PUT /api/messages` endpoint (`ImportMessage` in `MessagesController.cs`), `dbMessage` is constructed and added directly to `dbContext.Messages`. 
Unlike messages received via SMTP (`Smtp4devServer.ProcessMessage`) or IMAP `APPEND` (`SessionHandler.Session_Append`), `ImportMessage` was not setting `dbMessage.ImapUid`. 

As a result, `dbMessage.ImapUid` remained `0` (default value for `long`). When an IMAP client connects and selects the folder, `Session_GetMessagesInfo` reads all messages from the database and constructs `IMAP_MessageInfo` objects. In `LumiSoft.Net.IMAP.Server.IMAP_MessageInfo`, any `uid < 1` causes an `ArgumentException("Argument 'uid' value must be >= 1.", "uid")`, breaking the IMAP `SELECT` command.

## Proposed Changes

### Backend Core
- In `ImportMessage()`:
  - Retrieve `ImapState` from `dbContext.ImapState` (create an `ImapState` entry if none exists, consistent with `Startup.cs`).
  - Increment `imapState.LastUid` (`imapState.LastUid = Math.Max(0, imapState.LastUid + 1)`).
  - Assign `dbMessage.ImapUid = imapState.LastUid`.
  - Save changes to database.